### PR TITLE
Better handle interventions

### DIFF
--- a/src/y0/parser_utils.py
+++ b/src/y0/parser_utils.py
@@ -24,10 +24,7 @@ def _set_star(_s, _l, tokens: ParseResults):
 
 
 def _make_intervention(_s, _l, tokens: ParseResults):
-    if tokens['star']:
-        return Intervention(name=tokens['name'], star=True)
-    else:
-        return Variable(name=tokens['name'])
+    return Intervention(name=tokens['name'], star=bool(tokens['star']))
 
 
 def _unpack(_s, _l, tokens: ParseResults):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -37,6 +37,7 @@ class TestDSL(unittest.TestCase):
         self.assert_text('W', Intervention('W', False))
         self.assert_text('W', Intervention('W'))  # False is the default
         self.assert_text('W', W)  # shorthand for testing purposes
+        self.assert_text('W', -W)  # An intervention from variable W
 
         # inversions using the unary ~ operator
         self.assert_text('W', ~Intervention('W', True))
@@ -47,7 +48,7 @@ class TestDSL(unittest.TestCase):
     def test_counterfactual_variable(self):
         """Test the Counterfactual Variable DSL object."""
         # Normal instantiation
-        self.assert_text('Y_{W}', CounterfactualVariable('Y', [W]))
+        self.assert_text('Y_{W}', CounterfactualVariable('Y', [-W]))
         self.assert_text('Y_{W*}', CounterfactualVariable('Y', [~W]))
 
         # Instantiation with list-based operand to matmul @ operator


### PR DESCRIPTION
Inspired by #7, this PR normalizes the usage of intervention variables and introduces the unary minus `-` operator to turn a variable into a intervention with no star (to complement the unary not `~` operator, which makes an intervention with a star)