### PR TITLE
Make all dataclasses hashable

### DIFF
--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -8,7 +8,7 @@ import functools
 import itertools as itt
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, List, Sequence, Tuple, TypeVar, Union
+from typing import Callable, Iterable, Sequence, Tuple, TypeVar, Union
 
 __all__ = [
     'Variable',
@@ -26,10 +26,10 @@ __all__ = [
 ]
 
 X = TypeVar('X')
-XList = Union[X, List[X]]
+XSeq = Union[X, Sequence[X]]
 
 
-def _upgrade_variables(variables: XList[Variable]) -> Tuple[Variable, ...]:
+def _upgrade_variables(variables: XSeq[Variable]) -> Tuple[Variable, ...]:
     return (variables,) if isinstance(variables, Variable) else tuple(variables)
 
 
@@ -75,7 +75,7 @@ class Variable(_Mathable):
         """Output this variable in the LaTeX string format."""
         return self.to_text()
 
-    def intervene(self, variables: XList[Variable]) -> CounterfactualVariable:
+    def intervene(self, variables: XSeq[Variable]) -> CounterfactualVariable:
         """Intervene on this variable with the given variable(s).
 
         :param variables: The variable(s) used to extend this variable as it is changed to a
@@ -89,10 +89,10 @@ class Variable(_Mathable):
             interventions=_to_interventions(_upgrade_variables(variables)),
         )
 
-    def __matmul__(self, variables: XList[Variable]) -> CounterfactualVariable:
+    def __matmul__(self, variables: XSeq[Variable]) -> CounterfactualVariable:
         return self.intervene(variables)
 
-    def given(self, parents: Union[XList[Variable], Distribution]) -> Distribution:
+    def given(self, parents: Union[XSeq[Variable], Distribution]) -> Distribution:
         """Create a distribution in which this variable is conditioned on the given variable(s).
 
         The new distribution is a Markov Kernel.
@@ -118,10 +118,10 @@ class Variable(_Mathable):
                 parents=parents.children,  # don't think about this too hard
             )
 
-    def __or__(self, parents: XList[Variable]) -> Distribution:
+    def __or__(self, parents: XSeq[Variable]) -> Distribution:
         return self.given(parents)
 
-    def joint(self, children: XList[Variable]) -> Distribution:
+    def joint(self, children: XSeq[Variable]) -> Distribution:
         """Create a joint distribution between this variable and the given variable(s).
 
         :param children: The variable(s) for use with this variable in a joint distribution
@@ -133,7 +133,7 @@ class Variable(_Mathable):
             children=(self, *_upgrade_variables(children)),
         )
 
-    def __and__(self, children: XList[Variable]) -> Distribution:
+    def __and__(self, children: XSeq[Variable]) -> Distribution:
         return self.joint(children)
 
     def invert(self) -> Intervention:
@@ -210,7 +210,7 @@ class CounterfactualVariable(Variable):
         intervention_latex = ','.join(intervention.to_latex() for intervention in self.interventions)
         return f'{self.name}_{{{intervention_latex}}}'
 
-    def intervene(self, variables: XList[Variable]) -> CounterfactualVariable:
+    def intervene(self, variables: XSeq[Variable]) -> CounterfactualVariable:
         """Intervene on this counterfactual variable with the given variable(s).
 
         :param variables: The variable(s) used to extend this counterfactual variable's
@@ -285,7 +285,7 @@ class Distribution(_Mathable):
         """Return if this distribution a markov kernel -> one child variable and one or more conditionals."""
         return len(self.children) == 1
 
-    def joint(self, children: XList[Variable]) -> Distribution:
+    def joint(self, children: XSeq[Variable]) -> Distribution:
         """Create a new distribution including the given child variables.
 
         :param children: The variable(s) with which this distribution's children are extended
@@ -298,10 +298,10 @@ class Distribution(_Mathable):
             parents=self.parents,
         )
 
-    def __and__(self, children: XList[Variable]) -> Distribution:
+    def __and__(self, children: XSeq[Variable]) -> Distribution:
         return self.joint(children)
 
-    def given(self, parents: Union[XList[Variable], Distribution]) -> Distribution:
+    def given(self, parents: Union[XSeq[Variable], Distribution]) -> Distribution:
         """Create a new mixed distribution additionally conditioned on the given parent variables.
 
         :param parents: The variable(s) with which this distribution's parents are extended
@@ -325,7 +325,7 @@ class Distribution(_Mathable):
                 parents=(*self.parents, *parents.children),  # don't think about this too hard
             )
 
-    def __or__(self, parents: XList[Variable]) -> Distribution:
+    def __or__(self, parents: XSeq[Variable]) -> Distribution:
         return self.given(parents)
 
 

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -8,7 +8,7 @@ import functools
 import itertools as itt
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Callable, List, Tuple, TypeVar, Union
+from typing import Callable, Iterable, List, Sequence, Tuple, TypeVar, Union
 
 __all__ = [
     'Variable',
@@ -33,11 +33,11 @@ def _upgrade_variables(variables: XList[Variable]) -> List[Variable]:
     return [variables] if isinstance(variables, Variable) else variables
 
 
-def _to_interventions(variables: List[Variable]) -> List[Intervention]:
-    return [
+def _to_interventions(variables: Sequence[Variable]) -> Sequence[Intervention]:
+    return tuple(
         variable if isinstance(variable, Intervention) else Intervention(name=variable.name, star=False)
         for variable in variables
-    ]
+    )
 
 
 class _Mathable(ABC):
@@ -188,7 +188,7 @@ class CounterfactualVariable(Variable):
     #: The name of the counterfactual variable
     name: str
     #: The interventions on the variable. Should be non-empty
-    interventions: List[Intervention]
+    interventions: Sequence[Intervention]
 
     def __post_init__(self):
         if not self.interventions:
@@ -225,10 +225,10 @@ class CounterfactualVariable(Variable):
         self._raise_for_overlapping_interventions(_interventions)
         return CounterfactualVariable(
             name=self.name,
-            interventions=list(itt.chain(self.interventions, _interventions)),
+            interventions=tuple(itt.chain(self.interventions, _interventions)),
         )
 
-    def _raise_for_overlapping_interventions(self, interventions: List[Intervention]) -> None:
+    def _raise_for_overlapping_interventions(self, interventions: Iterable[Intervention]) -> None:
         """Raise an error if any of the given variables are already listed in interventions in this counterfactual.
 
         :param interventions: Interventions to check for overlap

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -345,10 +345,8 @@ class Expression(_Mathable, ABC):
 class Probability(Expression):
     """The probability over a distribution."""
 
+    #: The distribution over which the probability is expressed
     distribution: Distribution
-
-    def __hash__(self):
-        return hash((self.__class__, hash(self.distribution)))
 
     def to_text(self) -> str:
         """Output this probability in the internal string format."""

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -391,8 +391,6 @@ def P(  # noqa:N802
     :raises ValueError: If varidic args are used incorrectly (i.e., in combination with a
         list of variables or :class:`Distribution`.
 
-    .. note:: This class is so commonly used, that it is aliased as :class:`P`.
-
     Creation with a conditional distribution:
 
     >>> from y0.dsl import P, A, B

--- a/src/y0/parser.py
+++ b/src/y0/parser.py
@@ -17,7 +17,7 @@ expr = Forward()
 
 def _make_sum(_s, _l, tokens: ParseResults) -> Sum:
     return Sum(
-        ranges=tokens['ranges'].asList() if 'ranges' in tokens else [],
+        ranges=tuple(tokens['ranges'].asList()) if 'ranges' in tokens else tuple(),
         expression=tokens['expression'],
     )
 
@@ -34,7 +34,7 @@ def _make_product(_s, _l, tokens: ParseResults) -> Expression:
     if len(tokens) == 1:
         return tokens[0]
     else:
-        return Product(tokens)
+        return Product(tuple(tokens))
 
 
 # auto-product

--- a/src/y0/parser_utils.py
+++ b/src/y0/parser_utils.py
@@ -36,7 +36,7 @@ def _make_variable(_s, _l, tokens: ParseResults) -> Variable:
         return Variable(name=tokens['name'])
     return CounterfactualVariable(
         name=tokens['name'],
-        interventions=tokens['interventions'].asList(),
+        interventions=tuple(tokens['interventions'].asList()),
     )
 
 

--- a/src/y0/parser_utils.py
+++ b/src/y0/parser_utils.py
@@ -44,7 +44,7 @@ def _make_probability(_s, _l, tokens: ParseResults) -> Probability:
     children, parents = tokens['children'].asList(), tokens['parents'].asList()
     if not children:
         raise ValueError
-    return Probability(Distribution(children=children, parents=parents))
+    return Probability(Distribution(children=tuple(children), parents=tuple(parents)))
 
 
 # The suffix "pe" refers to :class:`pyparsing.ParserElement`, which is the

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -19,6 +19,7 @@ class TestDSL(unittest.TestCase):
     def assert_text(self, s: str, expression):
         """Assert the expression when it is converted to a string."""
         self.assertIsInstance(s, str)
+        self.assertIsInstance(hash(expression), int)  # can the expression be hashed?
         self.assertEqual(s, expression.to_text(), msg=f'Expression: {repr(expression)}')
 
     def test_variable(self):
@@ -48,8 +49,8 @@ class TestDSL(unittest.TestCase):
     def test_counterfactual_variable(self):
         """Test the Counterfactual Variable DSL object."""
         # Normal instantiation
-        self.assert_text('Y_{W}', CounterfactualVariable('Y', (-W, )))
-        self.assert_text('Y_{W*}', CounterfactualVariable('Y', (~W, )))
+        self.assert_text('Y_{W}', CounterfactualVariable('Y', (-W,)))
+        self.assert_text('Y_{W*}', CounterfactualVariable('Y', (~W,)))
 
         # Instantiation with list-based operand to matmul @ operator
         self.assert_text('Y_{W}', Variable('Y') @ [W])
@@ -58,7 +59,7 @@ class TestDSL(unittest.TestCase):
         self.assert_text('Y_{W*}', Y @ [~W])
 
         # Instantiation with two variables
-        self.assert_text('Y_{X,W*}', CounterfactualVariable('Y', [Intervention('X'), ~Intervention('W')]))
+        self.assert_text('Y_{X,W*}', CounterfactualVariable('Y', (Intervention('X'), ~Intervention('W'))))
 
         # Instantiation with matmul @ operator and single operand
         self.assert_text('Y_{W}', Y @ Intervention('W'))
@@ -79,11 +80,11 @@ class TestDSL(unittest.TestCase):
     def test_conditional_distribution(self):
         """Test the :class:`Distribution` DSL object."""
         # Normal instantiation
-        self.assert_text('A|B', Distribution(A, [B]))
+        self.assert_text('A|B', Distribution((A,), (B,)))
 
         # Instantiation with list-based operand to or | operator
-        self.assert_text('A|B', Variable('A') | [B])
-        self.assert_text('A|B', A | [B])
+        self.assert_text('A|B', Variable('A') | (B,))
+        self.assert_text('A|B', A | (B,))
 
         # # Instantiation with two variables
         self.assert_text('A|B,C', A | [B, C])
@@ -105,52 +106,52 @@ class TestDSL(unittest.TestCase):
 
     def test_joint_distribution(self):
         """Test the JointProbability DSL object."""
-        self.assert_text('A,B', Distribution([A, B]))
+        self.assert_text('A,B', Distribution((A, B)))
         self.assert_text('A,B', A & B)
-        self.assert_text('A,B,C', Distribution([A, B, C]))
+        self.assert_text('A,B,C', Distribution((A, B, C)))
         self.assert_text('A,B,C', A & B & C)
 
     def test_probability(self):
         """Test generation of probabilities."""
         # Make sure there are children
         with self.assertRaises(ValueError):
-            Distribution([])
+            Distribution(tuple())
 
         # Test markov kernels (AKA has only one child variable)
-        self.assert_text('P(A|B)', P(Distribution(A, [B])))
+        self.assert_text('P(A|B)', P(Distribution((A,), (B,))))
         self.assert_text('P(A|B)', P(A | [B]))
-        self.assert_text('P(A|B,C)', P(Distribution(A, [B]) | C))
+        self.assert_text('P(A|B,C)', P(Distribution((A,), (B,)) | C))
         self.assert_text('P(A|B,C)', P(A | [B, C]))
         self.assert_text('P(A|B,C)', P(A | B | C))
         self.assert_text('P(A|B,C)', P(A | B & C))
 
         # Test simple joint distributions
-        self.assert_text('P(A,B)', P([A, B]))
+        self.assert_text('P(A,B)', P((A, B)))
         self.assert_text('P(A,B)', P(A, B))
         self.assert_text('P(A,B)', P(A & B))
         self.assert_text('P(A,B,C)', P(A & B & C))
 
         # Test mixed with single conditional
-        self.assert_text('P(A,B|C)', P(Distribution([A, B], [C])))
-        self.assert_text('P(A,B|C)', P(Distribution([A, B], C)))
-        self.assert_text('P(A,B|C)', P(Distribution([A, B]) | C))
+        self.assert_text('P(A,B|C)', P(Distribution((A, B), (C,))))
+        self.assert_text('P(A,B|C)', P(Distribution((A, B), (C,))))
+        self.assert_text('P(A,B|C)', P(Distribution((A, B)) | C))
         self.assert_text('P(A,B|C)', P(A & B | C))
 
         # Test mixed with multiple conditionals
-        self.assert_text('P(A,B|C,D)', P(Distribution([A, B], [C, D])))
-        self.assert_text('P(A,B|C,D)', P(Distribution([A, B]) | C | D))
-        self.assert_text('P(A,B|C,D)', P(Distribution([A, B], [C]) | D))
+        self.assert_text('P(A,B|C,D)', P(Distribution((A, B), (C, D))))
+        self.assert_text('P(A,B|C,D)', P(Distribution((A, B)) | C | D))
+        self.assert_text('P(A,B|C,D)', P(Distribution((A, B), (C,)) | D))
         self.assert_text('P(A,B|C,D)', P(A & B | C | D))
-        self.assert_text('P(A,B|C,D)', P(A & B | [C, D]))
-        self.assert_text('P(A,B|C,D)', P(A & B | Distribution([C, D])))
+        self.assert_text('P(A,B|C,D)', P(A & B | (C, D)))
+        self.assert_text('P(A,B|C,D)', P(A & B | Distribution((C, D))))
         self.assert_text('P(A,B|C,D)', P(A & B | C & D))
 
     def test_conditioning_errors(self):
         """Test erroring on conditionals."""
         for expression in [
-            Distribution(B, C),
-            Distribution([B, C], D),
-            Distribution([B, C], [D, W]),
+            Distribution((B,), (C,)),
+            Distribution((B, C), (D,)),
+            Distribution((B, C), (D, W)),
         ]:
             with self.assertRaises(TypeError):
                 _ = A | expression
@@ -167,12 +168,12 @@ class TestDSL(unittest.TestCase):
         # Sum with one variable
         self.assert_text(
             "[ sum_{S} P(A|B) P(C|D) ]",
-            Sum(P(A | B) * P(C | D), [S]),
+            Sum(P(A | B) * P(C | D), (S,)),
         )
         # Sum with two variables
         self.assert_text(
             "[ sum_{S,T} P(A|B) P(C|D) ]",
-            Sum(P(A | B) * P(C | D), [S, T]),
+            Sum(P(A | B) * P(C | D), (S, T)),
         )
 
         # CRAZY sum syntax! pycharm doesn't like this usage of __class_getitem__ though so idk if we'll keep this
@@ -188,32 +189,32 @@ class TestDSL(unittest.TestCase):
         # Sum with sum inside
         self.assert_text(
             "[ sum_{S,T} P(A|B) [ sum_{Q} P(C|D) ] ]",
-            Sum(P(A | B) * Sum(P(C | D), [Q]), [S, T]),
+            Sum(P(A | B) * Sum(P(C | D), (Q,)), (S, T)),
         )
 
     def test_jeremy(self):
         """Test assorted complicated objects from Jeremy."""
         self.assert_text(
             '[ sum_{W} P(Y_{Z*,W},X) P(D) P(Z_{D}) P(W_{X*}) ]',
-            Sum(P((Y @ ~Z @ W) & X) * P(D) * P(Z @ D) * P(W @ ~X), [W]),
+            Sum(P((Y @ ~Z @ W) & X) * P(D) * P(Z @ D) * P(W @ ~X), (W,)),
         )
 
         self.assert_text(
             '[ sum_{W} P(Y_{Z*,W},X) P(W_{X*}) ]',
-            Sum(P(Y @ ~Z @ W & X) * P(W @ ~X), [W]),
+            Sum(P(Y @ ~Z @ W & X) * P(W @ ~X), (W,)),
         )
 
         self.assert_text(
             'frac_{[ sum_{W} P(Y_{Z,W},X) P(W_{X*}) ]}{[ sum_{Y} [ sum_{W} P(Y_{Z,W},X) P(W_{X*}) ] ]}',
             Fraction(
-                Sum(P(Y @ Z @ W & X) * P(W @ ~X), [W]),
-                Sum(Sum(P(Y @ Z @ W & X) * P(W @ ~X), [W]), [Y]),
+                Sum(P(Y @ Z @ W & X) * P(W @ ~X), (W,)),
+                Sum(Sum(P(Y @ Z @ W & X) * P(W @ ~X), (W,)), (Y,)),
             ),
         )
 
         self.assert_text(
             '[ sum_{D} P(Y_{Z*,W},X) P(D) P(Z_{D}) P(W_{X*}) ]',
-            Sum(P(Y @ ~Z @ W & X) * P(D) * P(Z @ D) * P(W @ ~X), [D]),
+            Sum(P(Y @ ~Z @ W & X) * P(D) * P(Z @ D) * P(W @ ~X), (D,)),
         )
 
         self.assert_text(

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -48,8 +48,8 @@ class TestDSL(unittest.TestCase):
     def test_counterfactual_variable(self):
         """Test the Counterfactual Variable DSL object."""
         # Normal instantiation
-        self.assert_text('Y_{W}', CounterfactualVariable('Y', [-W]))
-        self.assert_text('Y_{W*}', CounterfactualVariable('Y', [~W]))
+        self.assert_text('Y_{W}', CounterfactualVariable('Y', (-W, )))
+        self.assert_text('Y_{W*}', CounterfactualVariable('Y', (~W, )))
 
         # Instantiation with list-based operand to matmul @ operator
         self.assert_text('Y_{W}', Variable('Y') @ [W])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,7 +33,10 @@ class TestGrammar(unittest.TestCase):
         result_expression = parse_result.asList()[0]
         self.assertIsInstance(result_expression, expression.__class__)
         if direct:
-            self.assertEqual(expression, result_expression)
+            self.assertEqual(
+                expression, result_expression,
+                msg=f'Mismatch\nExpected: {repr(expression)}\nActual:   {repr(result_expression)}',
+            )
         else:
             self.assertEqual(text, result_expression.to_text())
 


### PR DESCRIPTION
All dataclasses with a `List[X]` datatype were changed to a `Tuple[X, ...]`. Lists are mutable and not hashable, while tuples are immutable and hashable.

All dataclasses were switched to have `frozen=True`, but this means that introspection can't be done in `__post_init__`. 

The `P` alias was switched to a proper function that better handles user idioms