### PR TITLE
Add predicate for markov postcondition

### DIFF
--- a/src/y0/predicates.py
+++ b/src/y0/predicates.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+"""Predicates for expressions."""
+
+from .dsl import Expression, Fraction, Probability, Product, Sum
+
+__all__ = [
+    'has_markov_postcondition',
+]
+
+
+def has_markov_postcondition(expression: Expression) -> bool:
+    """Check that the expression is a sum/product of markov kernels.
+
+    :param expression: Any expression
+    :return: if the expression satisfies the sum/product of markov kernels condition
+    :raises TypeError: if an object with an invalid type is passed
+    """
+    if isinstance(expression, Probability):
+        return expression.distribution.is_markov_kernel()
+    elif isinstance(expression, Product):
+        return all(
+            has_markov_postcondition(subexpr)
+            for subexpr in expression.expressions
+        )
+    elif isinstance(expression, Sum):
+        return has_markov_postcondition(expression.expression)
+    elif isinstance(expression, Fraction):
+        return has_markov_postcondition(expression.numerator) and has_markov_postcondition(expression.denominator)
+    else:
+        raise TypeError

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for expression predicates."""
+
+import unittest
+
+from y0.dsl import A, B, C, D, P, Sum, Variable, X
+from y0.predicates import has_markov_postcondition
+
+
+class TestMarkovCondition(unittest.TestCase):
+    """Tests for checking the markov condition."""
+
+    def test_markov_raises(self):
+        """Test the type error is raised on invalid input."""
+        for value in [
+            Variable('whatever'),
+            A @ B,
+            A @ ~B,
+            'something else',
+        ]:
+            with self.subTest(value=value), self.assertRaises(TypeError):
+                has_markov_postcondition(value)
+
+    def test_markov_postcondition(self):
+        """Test the expressions have the markov postcondition."""
+        for expression in [
+            P(A),
+            P(A | B),
+            P(A | (B, C)),
+            P(A) * P(B),
+            P(A) * P(A | B),
+            P(A | B) * P(A | C),
+            P(A) / P(B),
+            P(A) / P(A | B),
+            Sum[X](P(A)),
+            Sum[X](P(A | B)),
+            Sum[X](P(A | B) * P(B)),
+        ]:
+            with self.subTest(e=expression):
+                self.assertTrue(has_markov_postcondition(expression))
+
+    def test_missing_markov_postcondition(self):
+        """Test the expressions do not have the markov postcondition."""
+        for expression in [
+            P(A, B),
+            P(A & B | C),
+            P(A & D | (B, C)),
+            P(A, C) * P(B),
+            P(A, C) * P(A | B),
+            P(A) * P(A & C | B),
+            P(A & C | B) * P(A | C),
+            P(A) / P(B & C),
+            P(A & C) / P(B),
+            P(A) / P(A & C | B),
+            Sum[X](P(A, C)),
+            Sum[X](P(A & C | B)),
+            Sum[X](P(A & C | B) * P(B)),
+            Sum[X](P(A | B) * P(B, C)),
+        ]:
+            with self.subTest(e=str(expression)):
+                self.assertFalse(has_markov_postcondition(expression))


### PR DESCRIPTION
The markov postcondition is that all of the distributions appearing in an expression are markov kernels.