### PR TITLE
Implement canonicalize() algorithm

### DIFF
--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -613,3 +613,10 @@ class One(Expression):
 
 
 A, B, C, D, Q, S, T, W, X, Y, Z = map(Variable, 'ABCDQSTWXYZ')  # type: ignore
+
+
+def _upgrade_ordering(variables: Sequence[Union[str, Variable]]) -> Sequence[Variable]:
+    return tuple(
+        Variable(variable) if isinstance(variable, str) else variable
+        for variable in variables
+    )

--- a/src/y0/mutate/__init__.py
+++ b/src/y0/mutate/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Functions that mutate probability expressions."""

--- a/src/y0/mutate/canonicalize.py
+++ b/src/y0/mutate/canonicalize.py
@@ -4,7 +4,7 @@
 
 from typing import Sequence, Union
 
-from ..dsl import Distribution, Expression, Fraction, Probability, Product, Sum, Variable
+from ..dsl import Distribution, Expression, Fraction, Probability, Product, Sum, Variable, _upgrade_ordering
 from ..predicates import has_markov_postcondition
 
 __all__ = [
@@ -30,13 +30,6 @@ def canonicalize(expression: Expression, ordering: Sequence[Union[str, Variable]
 
     canonicalizer = Canonicalizer(ordering)
     return canonicalizer.canonicalize(expression)
-
-
-def _upgrade_ordering(variables: Sequence[Union[str, Variable]]) -> Sequence[Variable]:
-    return tuple(
-        Variable(variable) if isinstance(variable, str) else variable
-        for variable in variables
-    )
 
 
 def _sort_probability_key(probability: Probability) -> str:

--- a/src/y0/mutate/canonicalize.py
+++ b/src/y0/mutate/canonicalize.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+"""Implementation of the canonicalization algorithm."""
+
+from typing import Sequence, Union
+
+from ..dsl import Distribution, Expression, Fraction, Probability, Product, Sum, Variable
+from ..predicates import has_markov_postcondition
+
+__all__ = [
+    'canonicalize',
+]
+
+
+def canonicalize(expression: Expression, ordering: Sequence[Union[str, Variable]]) -> Expression:
+    """Canonicalize an expression that meets the markov condition with respect to the given ordering.
+
+    :param expression: An expression to canonicalize
+    :param ordering: A toplogical ordering
+    :return: A canonical expression
+    :raises ValueError: if the expression does not pass the markov postcondition
+    :raises ValueError: if the ordering has duplicates
+    """
+    if not has_markov_postcondition(expression):
+        raise ValueError(f'can not canonicalize expression that does not have the markov postcondition: {expression}')
+
+    ordering = _upgrade_ordering(ordering)
+    if len(set(ordering)) != len(ordering):
+        raise ValueError(f'ordering has duplicates: {ordering}')
+
+    canonicalizer = Canonicalizer(ordering)
+    return canonicalizer.canonicalize(expression)
+
+
+def _upgrade_ordering(variables: Sequence[Union[str, Variable]]) -> Sequence[Variable]:
+    return tuple(
+        Variable(variable) if isinstance(variable, str) else variable
+        for variable in variables
+    )
+
+
+def _sort_probability_key(probability: Probability) -> str:
+    return probability.distribution.children[0].name
+
+
+class Canonicalizer:
+    """A data structure to support application of the canonicalize algorithm."""
+
+    def __init__(self, ordering: Sequence[Variable]) -> None:
+        """Initialize the canonicalizer.
+
+        :param ordering: A topological ordering over the variables appearing in the expression.
+        """
+        self.ordering = ordering
+        self.ordering_level = {
+            variable: level
+            for level, variable in enumerate(self.ordering)
+        }
+
+    def canonicalize(self, expression: Expression) -> Expression:
+        """Canonicalize an expression.
+
+        :param expression: An uncanonicalized expression
+        :return: A canonicalized expression
+        :raises TypeError: if an object with an invalid type is passed
+        """
+        if isinstance(expression, Probability):  # atomic
+            return Probability(Distribution(
+                children=expression.distribution.children,
+                parents=tuple(sorted(expression.distribution.parents, key=self.ordering_level.__getitem__)),
+            ))
+        elif isinstance(expression, Sum):
+            if isinstance(expression.expression, Probability):  # also atomic
+                return expression
+
+            return Sum(
+                expression=self.canonicalize(expression.expression),
+                ranges=expression.ranges,
+            )
+        elif isinstance(expression, Product):
+            probabilities = []
+            other = []
+            for subexpr in expression.expressions:
+                subexpr = self.canonicalize(subexpr)
+                if isinstance(subexpr, Probability):
+                    probabilities.append(subexpr)
+                else:
+                    other.append(subexpr)
+            probabilities = sorted(probabilities, key=_sort_probability_key)
+            other = sorted(other, key=self._nonatomic_key)
+            return Product((*probabilities, *other))
+        elif isinstance(expression, Fraction):
+            return Fraction(
+                numerator=self.canonicalize(expression.numerator),
+                denominator=self.canonicalize(expression.denominator),
+            )
+        else:
+            raise TypeError
+
+    def _nonatomic_key(self, expression: Expression):
+        raise NotImplementedError('nonatomic sort not implemented')

--- a/tests/test_mutate/__init__.py
+++ b/tests/test_mutate/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for functions that mutate probability expressions."""

--- a/tests/test_mutate/test_canonicalize.py
+++ b/tests/test_mutate/test_canonicalize.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for the canonicalization algorithm."""
+
+import itertools as itt
+import unittest
+from typing import Sequence
+
+from y0.dsl import A, B, C, D, Expression, P, Sum, Variable, X, Y, Z
+from y0.mutate.canonicalize import canonicalize
+
+
+class TestCanonicalize(unittest.TestCase):
+    """Tests for the canonicalization of a simplified algorithm."""
+
+    def test_canonicalize_raises(self):
+        """Test a value error is raised for non markov-conditioning expressions."""
+        with self.assertRaises(ValueError):
+            canonicalize(P(A, B, C), [A, B, C])
+
+    def assert_canonicalize(self, expected: Expression, expression: Expression, ordering: Sequence[Variable]) -> None:
+        """Check that the expression is canonicalized properly given an ordering."""
+        with self.subTest(expr=str(expression), ordering=', '.join(variable.name for variable in ordering)):
+            self.assertEqual(expected, canonicalize(expression, ordering))
+
+    def test_atomic(self):
+        """Test canonicalization of atomic expressions."""
+        for expected, expression, ordering in [
+            (P(A), P(A), [A]),
+            (P(A | B), P(A | B), [A, B]),
+            (P(A | (B, C)), P(A | (B, C)), [A, B, C]),
+            (P(A | (B, C)), P(A | (C, B)), [A, B, C]),
+        ]:
+            self.assert_canonicalize(expected, expression, ordering)
+
+        expected = P(A | (B, C, D))
+        for b, c, d in itt.permutations((B, C, D)):
+            expression = P(A | (b, c, d))
+            self.assert_canonicalize(expected, expression, [A, B, C, D])
+
+    def test_derived_atomic(self):
+        """Test canonicalizing."""
+        # Sum
+        expected = expression = Sum(P(A))
+        self.assert_canonicalize(expected, expression, [A])
+
+        # Simple product (only atomic)
+        expected = P(A) * P(B) * P(C)
+        for a, b, c in itt.permutations((P(A), P(B), P(C))):
+            expression = a * b * c
+            self.assert_canonicalize(expected, expression, [A, B, C])
+
+        # Sum with simple product (only atomic)
+        expected = Sum(P(A) * P(B) * P(C))
+        for a, b, c in itt.permutations((P(A), P(B), P(C))):
+            expression = Sum(a * b * c)
+            self.assert_canonicalize(expected, expression, [A, B, C])
+
+        # Fraction
+        expected = expression = P(A) / P(B)
+        self.assert_canonicalize(expected, expression, [A, B])
+
+        # Fraction with simple products (only atomic)
+        expected = (P(A) * P(B) * P(C)) / (P(X) * P(Y) * P(Z))
+        for (a, b, c), (x, y, z) in itt.product(
+            itt.permutations((P(A), P(B), P(C))),
+            itt.permutations((P(X), P(Y), P(Z))),
+        ):
+            expression = (a * b * c) / (x * y * z)
+            self.assert_canonicalize(expected, expression, [A, B, C, X, Y, Z])
+
+    def test_mixed(self):
+        """Test mixed expressions."""
+        expected = expression = P(A) * Sum(P(B))
+        self.assert_canonicalize(expected, expression, [A, B])
+
+        expected = P(A) * Sum(P(B)) * Sum(P(C))
+        for a, b, c in itt.permutations((P(A), Sum(P(B)), Sum(P(C)))):
+            expression = a * b * c
+            self.assert_canonicalize(expected, expression, [A, B, C])
+
+        expected = P(D) * Sum(P(A) * P(B) * P(C))
+        for a, b, c in itt.permutations((P(A), P(B), P(C))):
+            sum_expr = Sum(a * b * c)
+            for left, right in itt.permutations((P(D), sum_expr)):
+                self.assert_canonicalize(expected, left * right, [A, B, C, D])
+
+        expected = Sum(P(A) * P(B)) * Sum(P(C) * P(D))
+        for (a, b), (c, d) in itt.permutations(itt.product(
+            itt.permutations((P(A), P(B))),
+            itt.permutations((P(C), P(D))),
+        )):
+            expression = Sum(a * b) * Sum(c * d)
+            self.assert_canonicalize(expected, expression * P(D), [A, B, C, D])

--- a/tests/test_mutate/test_canonicalize.py
+++ b/tests/test_mutate/test_canonicalize.py
@@ -85,10 +85,11 @@ class TestCanonicalize(unittest.TestCase):
             for left, right in itt.permutations((P(D), sum_expr)):
                 self.assert_canonicalize(expected, left * right, [A, B, C, D])
 
-        expected = Sum(P(A) * P(B)) * Sum(P(C) * P(D))
-        for (a, b), (c, d) in itt.permutations(itt.product(
+        expected = P(X) * Sum(P(A) * P(B)) * Sum(P(C) * P(D))
+        for (a, b), (c, d) in itt.product(
             itt.permutations((P(A), P(B))),
             itt.permutations((P(C), P(D))),
-        )):
-            expression = Sum(a * b) * Sum(c * d)
-            self.assert_canonicalize(expected, expression * P(D), [A, B, C, D])
+        ):
+            sexpr = Sum(a * b) * Sum(c * d)
+            self.assert_canonicalize(expected, sexpr * P(X), [A, B, C, D])
+            self.assert_canonicalize(expected, P(X) * sexpr, [A, B, C, D])

--- a/tests/test_mutate/test_canonicalize.py
+++ b/tests/test_mutate/test_canonicalize.py
@@ -97,3 +97,9 @@ class TestCanonicalize(unittest.TestCase):
             sexpr = Sum(a * b) * Sum(c * d)
             self.assert_canonicalize(expected, sexpr * P(X), [A, B, C, D])
             self.assert_canonicalize(expected, P(X) * sexpr, [A, B, C, D])
+
+        expected = expression = Sum(P(A) / P(B))
+        self.assert_canonicalize(expected, expression, [A, B])
+
+        expected = expression = Sum(P(A) / Sum(P(B))) * Sum(P(A) / Sum(P(B) / P(C)))
+        self.assert_canonicalize(expected, expression, [A, B, C])

--- a/tests/test_mutate/test_canonicalize.py
+++ b/tests/test_mutate/test_canonicalize.py
@@ -21,7 +21,11 @@ class TestCanonicalize(unittest.TestCase):
     def assert_canonicalize(self, expected: Expression, expression: Expression, ordering: Sequence[Variable]) -> None:
         """Check that the expression is canonicalized properly given an ordering."""
         with self.subTest(expr=str(expression), ordering=', '.join(variable.name for variable in ordering)):
-            self.assertEqual(expected, canonicalize(expression, ordering))
+            actual = canonicalize(expression, ordering)
+            self.assertEqual(
+                expected, actual,
+                msg=f'\nExpected: {str(expression)}\nActual:   {str(actual)}',
+            )
 
     def test_atomic(self):
         """Test canonicalization of atomic expressions."""


### PR DESCRIPTION
This PR implements (an apparently novel?) algorithm for canonicalizing the representation of a given probability expression that satisfies the markov postcondition (though, I don't think that this condition is actually necessary and can be relaxed in a later PR).

A "canonical" expression is generated with respect to an ordering over the variables appearing in the expression. It has the following properties:

- within a product or fraction (even stand alone probabilites are considered to be a 1-element product), the probability terms appear first, then sum expressions.
- probabilities are sorted with respect to their child variable name (given priority based on the given ordering)
- sums are sorted with respect to a recursive call to the "key" function

TODO:

- [x] implement tests
- [x] implement recursive algorithm
- [x] implement sort key for expressions (done in 1f61dcf)