### PR TITLE
Add basic web app

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,10 @@ docs =
     sphinx_automodapi
     # To include LaTeX comments easily in your docs
     texext
+web =
+    flask
+    bootstrap-flask
+    flask-wtf
 
 [options.entry_points]
 console_scripts =

--- a/src/y0/app/__init__.py
+++ b/src/y0/app/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""The y0 web application."""

--- a/src/y0/app/templates/base.html
+++ b/src/y0/app/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+    {% block head %}
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    {% block styles %}
+    <!-- Bootstrap CSS -->
+    {{ bootstrap.load_css() }}
+    {% endblock %}
+
+    <script src="https://kit.fontawesome.com/4c86883252.js" crossorigin="anonymous"></script>
+
+    <title>{% block title %}{% endblock %}</title>
+    {% endblock %}
+</head>
+<body>
+<!-- Your page content -->
+{% block content %}{% endblock %}
+
+{% block scripts %}
+<!-- Optional JavaScript -->
+{{ bootstrap.load_js() }}
+{% endblock %}
+</body>
+</html>

--- a/src/y0/app/templates/home.html
+++ b/src/y0/app/templates/home.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% import "bootstrap/form.html" as wtf %}
+{% import "bootstrap/utils.html" as util %}
+
+{% block title %}y0 Parser{% endblock %}
+
+{% block content %}
+<div class="container" style="margin-top: 50px; margin-bottom: 50px">
+    {{ util.render_messages(dismissible=True, container=False) }}
+    <div class="row justify-content-center">
+        <div class="col-md-8 col-sm-8 col-lg-8">
+            <div class="card">
+                <h5 class="card-header text-center">y0 Canonicalizer</h5>
+                <div class="card-body">
+                    <p>Enter a probability expression satisfying the markov postcondition.</p>
+                    {{ wtf.render_form(form) }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/y0/app/wsgi.py
+++ b/src/y0/app/wsgi.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+"""A web application exposing y0 functionality."""
+
+import os
+from typing import Sequence
+
+import flask
+import flask_bootstrap
+import pyparsing
+from flask import flash, render_template
+from flask_wtf import FlaskForm
+from wtforms import RadioField, StringField, SubmitField
+
+from y0.dsl import Expression, Variable, _upgrade_variables
+from y0.mutate.canonicalize import canonicalize
+from y0.parser import parse_craig, parse_y0
+
+app = flask.Flask(__name__)
+app.config['WTF_CSRF_ENABLED'] = False
+app.config['SECRET_KEY'] = os.urandom(8)
+
+flask_bootstrap.Bootstrap(app)
+
+LANGUAGES = {
+    'y0': parse_y0,
+    'craig': parse_craig,
+}
+
+
+class CanonicalizeForm(FlaskForm):
+    """Form for parsing and canonicalizing a probability expression."""
+
+    expression = StringField('Expression')
+    ordering = StringField('Ordering')
+    language = RadioField(
+        'Language',
+        default='y0',
+        choices=[
+            ('y0', 'y0 DSL'),
+            ('craig', 'Craig-like'),
+        ],
+    )
+    submit = SubmitField('Parse')
+
+    def parse_expression(self) -> Expression:
+        """Parse the expression."""
+        s = self.expression.data.strip().upper()
+        return LANGUAGES[self.language.data](s)
+
+    def parse_ordering(self) -> Sequence[Variable]:
+        """Parse the ordering."""
+        return _upgrade_variables(self.ordering.data.upper().split(','))
+
+
+@app.route('/', methods=['GET', 'POST'])
+def home():
+    """Render the home page."""
+    form = CanonicalizeForm()
+    if form.is_submitted():
+        try:
+            expression = form.parse_expression()
+        except pyparsing.ParseException:
+            flash(f'Invalid input: {form.expression.data}')
+        else:
+            ordering = form.parse_ordering()
+            try:
+                canonical_expression = canonicalize(expression, ordering)
+            except KeyError as e:
+                flash(f'Missing variable in ordering: {e.args[0].name}')
+            else:
+                flash(flask.Markup(
+                    f'Input y0:     {expression.to_text()}<br />'
+                    f'Canon y0: {canonical_expression.to_text()}',
+                ))
+    return render_template('home.html', form=form)
+
+
+if __name__ == '__main__':
+    app.run()

--- a/src/y0/app/wsgi.py
+++ b/src/y0/app/wsgi.py
@@ -14,7 +14,7 @@ from wtforms import RadioField, StringField, SubmitField
 
 from y0.dsl import Expression, Variable, _upgrade_variables
 from y0.mutate.canonicalize import canonicalize
-from y0.parser import parse_craig, parse_y0
+from y0.parser import parse_causaleffect, parse_craig, parse_y0
 
 app = flask.Flask(__name__)
 app.config['WTF_CSRF_ENABLED'] = False
@@ -25,6 +25,7 @@ flask_bootstrap.Bootstrap(app)
 LANGUAGES = {
     'y0': parse_y0,
     'craig': parse_craig,
+    'ce': parse_causaleffect,
 }
 
 
@@ -39,6 +40,7 @@ class CanonicalizeForm(FlaskForm):
         choices=[
             ('y0', 'y0 DSL'),
             ('craig', 'Craig-like'),
+            ('ce', 'Causaleffect'),
         ],
     )
     submit = SubmitField('Parse')

--- a/src/y0/cli.py
+++ b/src/y0/cli.py
@@ -16,6 +16,7 @@ later, but that will cause problems--the code will get executed twice:
 import logging
 
 import click
+from more_click import make_web_command
 
 __all__ = ['main']
 
@@ -27,6 +28,8 @@ logger = logging.getLogger(__name__)
 def main():
     """CLI for y0."""
 
+
+make_web_command('y0.app.wsgi:app', group=main)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR adds a structure for a small web app. Right now it just canonicalizes a given probability expression. It can parse either Craig-like expressions or y0 DSL expressions.

Run with `y0 web` after pip installing the `[web]` option with `pip install -e .[web]` (or `pip install y0[web]`, after the next PyPI release)