### PR TITLE
Implementation to calcualte Verma constraints

### DIFF
--- a/src/y0/algorithm/verma_constraints.py
+++ b/src/y0/algorithm/verma_constraints.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""Implementation to get Verma constraints on a graph."""
+
+from __future__ import annotations
+
+from typing import Iterable, NamedTuple, Set, Tuple
+
+from ananke.graphs import ADMG
+
+from ..dsl import Expression
+
+__all__ = [
+    'VermaConstraint',
+    'get_verma_constraints',
+]
+
+
+class VermaConstraint(NamedTuple):
+    """A Verma constraint."""
+
+    expression: Expression
+    nodes: Tuple[str, ...]
+
+    @property
+    def is_canonical(self) -> bool:
+        """Return if the nodes are in a canonical order."""
+        return tuple(sorted(self.nodes)) == self.nodes
+
+    @classmethod
+    def create(cls, expression, nodes: Iterable[str]) -> VermaConstraint:
+        """Create a canonical Verma constraint."""
+        return VermaConstraint(expression, tuple(sorted(set(nodes))))
+
+
+def get_verma_constraints(graph: ADMG) -> Set[VermaConstraint]:
+    """Get the Verma constraints on the graph.
+
+    :param graph: An acyclic directed mixed graph
+    :return: A set of verma constraings, which are pairs of probability expressions and set of nodes.
+
+    .. seealso:: Original issue https://github.com/y0-causal-inference/y0/issues/25
+    """
+    raise NotImplementedError

--- a/tests/test_algorithm/test_verma_constraint.py
+++ b/tests/test_algorithm/test_verma_constraint.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+"""Test getting Verma constraints."""
+
+import unittest
+from typing import Set
+
+from y0.algorithm.verma_constraints import VermaConstraint, get_verma_constraints
+from y0.graph import NxMixedGraph, napkin_graph
+
+
+class TestVermaConstraints(unittest.TestCase):
+    """Test getting Verma constraints."""
+
+    def assert_verma_constraints(self, graph: NxMixedGraph, expected: Set[VermaConstraint]):
+        """Assert that the graph has the correct conditional independencies."""
+        verma_constraints = get_verma_constraints(graph.to_admg())
+        self.assertTrue(
+            all(
+                verma_constraint.is_canonical
+                for verma_constraint in verma_constraints
+            ),
+            msg='one or more of the returned VermaConstraint instances are not canonical',
+        )
+        self.assertEqual(expected, verma_constraints)
+
+    def test_napkin(self):
+        """Test getting Verma constraints on the napkin graph."""
+        # TODO how is Q[Y](Y, X, V1) represented as an expression?
+        c1 = VermaConstraint(..., ('R',))
+        self.assert_verma_constraints(napkin_graph, {c1})


### PR DESCRIPTION
Closes #25

This pull request implements an algorithm to calculate all Verma constraints in a given ADMG.

- [x] Add outline of implementation, signature, and tests (@cthoyt; 368d63d)
- [ ] Decide on a data structure to store the  "expression" in a Verma constraint (@y0-causal-inference/y0-team)
- [ ] Implementation (@djinnome or @JosephCottam, please assign yourself)
