### PR TITLE
Add initial wrapper around causaleffect R package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,8 @@ package_dir =
 where = src
 
 [options.extras_require]
+r =
+    rpy2
 docs =
     sphinx
     sphinx-rtd-theme

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -54,6 +54,7 @@ class VermaConstraint(NamedTuple):
     lhs_expr: str
     rhs_cfactor: str
     rhs_expr: str
+    variables: str
 
     @classmethod
     def from_element(cls, element) -> VermaConstraint:
@@ -69,6 +70,7 @@ class VermaConstraint(NamedTuple):
             rhs_expr=element.rx('rhs.expr')[0][0],
             lhs_cfactor=element.rx('lhs.cfactor')[0][0],
             lhs_expr=element.rx('lhs.expr')[0][0],
+            variables=element.rx('vars')[0][0],
         )
 
 

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -9,11 +9,11 @@ from typing import NamedTuple, Sequence, Tuple, Union
 
 from rpy2 import robjects
 
-from y0.dsl import Expression, Variable
-from y0.examples import verma_1
-from y0.graph import CausalEffectGraph, NxMixedGraph
-from y0.parser import parse_causaleffect
-from y0.r_utils import uses_r
+from .dsl import Expression, Variable
+from .examples import verma_1
+from .graph import CausalEffectGraph, NxMixedGraph
+from .parser import parse_causaleffect
+from .r_utils import uses_r
 
 logger = logging.getLogger(__name__)
 

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -10,7 +10,7 @@ from rpy2 import robjects
 from rpy2.robjects.packages import importr, isinstalled
 from rpy2.robjects.vectors import StrVector
 
-from y0.graph import napkin_graph
+from y0.graph import figure_1
 
 logger = logging.getLogger(__name__)
 
@@ -54,10 +54,11 @@ def _main():
     importr(CAUSALEFFECT)
     importr(IGRAPH)
 
-    graph_code = napkin_graph.to_causaleffect_str()
+    graph_code = figure_1.to_causaleffect_str()
     graph = robjects.r(graph_code)
     print(graph)
 
+    # Get verma constraints
     verma_constraints = robjects.r['verma.constraints']
     rv = verma_constraints(graph)
     print(rv[0].rx('rhs.cfactor'))

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -2,15 +2,16 @@
 
 """Interface to the R causaleffect package via :mod:`rpy2`."""
 
-import logging
-from typing import Iterable
+from __future__ import annotations
 
-import pystow
+import logging
+from typing import Iterable, NamedTuple, Sequence
+
 from rpy2 import robjects
 from rpy2.robjects.packages import importr, isinstalled
 from rpy2.robjects.vectors import StrVector
 
-from y0.graph import figure_1
+from y0.graph import NxMixedGraph, figure_1
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +22,6 @@ R_REQUIREMENTS = [
     CAUSALEFFECT,
     IGRAPH,
 ]
-
-Y0_R_LIB_LOC = pystow.get('y0', 'r')
 
 
 def prepare_renv(*, requirements: Iterable[str]) -> None:
@@ -48,23 +47,55 @@ def prepare_renv(*, requirements: Iterable[str]) -> None:
         utils.install_packages(StrVector(requirements))
 
 
+class VermaConstraint(NamedTuple):
+    """Represent a Verma constraint output by causaleffect."""
+
+    lhs_cfactor: str
+    lhs_expr: str
+    rhs_cfactor: str
+    rhs_expr: str
+
+    @classmethod
+    def from_element(cls, element) -> VermaConstraint:
+        """Extract content from each element in the vector returned by `verma.constraint`.
+
+        :param element: An element in the in the vector returned by `verma.constraint`
+        :returns: A Verma constraint tuple for the given element
+
+        .. seealso:: Extracting from R objects https://rpy2.github.io/doc/v3.4.x/html/vector.html#extracting-items
+        """
+        return cls(
+            rhs_cfactor=element.rx('rhs.cfactor')[0][0],
+            rhs_expr=element.rx('rhs.expr')[0][0],
+            lhs_cfactor=element.rx('lhs.cfactor')[0][0],
+            lhs_expr=element.rx('lhs.expr')[0][0],
+        )
+
+
+def r_get_verma_constraints(graph) -> Sequence[VermaConstraint]:
+    """Calculate the verma constraints on the graph using ``causaleffect``."""
+    if isinstance(graph, NxMixedGraph):
+        graph = graph.to_causaleffect()
+    verma_constraints = robjects.r['verma.constraints']
+    return [
+        VermaConstraint.from_element(row)
+        for row in verma_constraints(graph)
+    ]
+
+
 def _main():
     prepare_renv(requirements=R_REQUIREMENTS)
 
     importr(CAUSALEFFECT)
     importr(IGRAPH)
 
-    graph_code = figure_1.to_causaleffect_str()
-    graph = robjects.r(graph_code)
+    graph = figure_1.to_causaleffect()
     print(graph)
 
     # Get verma constraints
-    verma_constraints = robjects.r['verma.constraints']
-    rv = verma_constraints(graph)
-    print(rv[0].rx('rhs.cfactor'))
-    print(rv[0].rx('rhs.expr'))
-    print(rv[0].rx('lhs.cfactor'))
-    print(rv[0].rx('lhs.expr'))
+    # see also: https://rpy2.github.io/doc/v3.4.x/html/vector.html#extracting-items
+    verma_constraints = r_get_verma_constraints(graph)
+    print(*verma_constraints, sep='\n')
 
 
 if __name__ == '__main__':

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -52,9 +52,9 @@ def prepare_renv(*, requirements: Iterable[str]) -> None:
 class VermaConstraint(NamedTuple):
     """Represent a Verma constraint output by causaleffect."""
 
-    lhs_cfactor: Expression
+    lhs_cfactor: str
     lhs_expr: Expression
-    rhs_cfactor: Expression
+    rhs_cfactor: str
     rhs_expr: Expression
     variables: str  # TODO should be a list of variables. What is the delimiter? need example with multiple
 
@@ -68,9 +68,9 @@ class VermaConstraint(NamedTuple):
         .. seealso:: Extracting from R objects https://rpy2.github.io/doc/v3.4.x/html/vector.html#extracting-items
         """
         return cls(
-            rhs_cfactor=parse_causaleffect(_extract(element, 'rhs.cfactor')),
+            rhs_cfactor=_extract(element, 'rhs.cfactor'),
             rhs_expr=parse_causaleffect(_extract(element, 'rhs.expr')),
-            lhs_cfactor=parse_causaleffect(_extract(element, 'lhs.cfactor')),
+            lhs_cfactor=_extract(element, 'lhs.cfactor'),
             lhs_expr=parse_causaleffect(_extract(element, 'lhs.expr')),
             variables=_parse_vars(_extract(element, 'vars')),
         )

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+"""Interface to the R causaleffect package via :mod:`rpy2`."""
+
+import logging
+from typing import Iterable
+
+import pystow
+from rpy2 import robjects
+from rpy2.robjects.packages import importr, isinstalled
+from rpy2.robjects.vectors import StrVector
+
+from y0.graph import napkin_graph
+
+logger = logging.getLogger(__name__)
+
+CAUSALEFFECT = 'causaleffect'
+IGRAPH = 'igraph'
+
+R_REQUIREMENTS = [
+    CAUSALEFFECT,
+    IGRAPH,
+]
+
+Y0_R_LIB_LOC = pystow.get('y0', 'r')
+
+
+def prepare_renv(*, requirements: Iterable[str]) -> None:
+    """Ensure the given R packages are installed.
+
+    :param requirements: A list of R packages to ensure are installed
+
+    .. seealso:: https://rpy2.github.io/doc/v3.4.x/html/introduction.html#installing-packages
+    """
+    # import R's utility package
+    utils = importr('utils')
+
+    # select a mirror for R packages
+    utils.chooseCRANmirror(ind=1)  # select the first mirror in the list
+
+    requirements = [
+        requirement
+        for requirement in requirements
+        if not isinstalled(requirement)
+    ]
+    if requirements:
+        logger.warning('installing R packages: %s', requirements)
+        utils.install_packages(StrVector(requirements))
+
+
+def _main():
+    prepare_renv(requirements=R_REQUIREMENTS)
+
+    importr(CAUSALEFFECT)
+    importr(IGRAPH)
+
+    graph_code = napkin_graph.to_causaleffect_str()
+    graph = robjects.r(graph_code)
+    print(graph)
+
+    verma_constraints = robjects.r['verma.constraints']
+    rv = verma_constraints(graph)
+    print(rv[0].rx('rhs.cfactor'))
+    print(rv[0].rx('rhs.expr'))
+    print(rv[0].rx('lhs.cfactor'))
+    print(rv[0].rx('lhs.expr'))
+
+
+if __name__ == '__main__':
+    _main()

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -68,7 +68,6 @@ class VermaConstraint(NamedTuple):
         .. seealso:: Extracting from R objects https://rpy2.github.io/doc/v3.4.x/html/vector.html#extracting-items
         """
         return cls(
-            lhs_cfactor=element.rx('lhs.cfactor')[0][0],
             rhs_cfactor=parse_causaleffect(_extract(element, 'rhs.cfactor')),
             rhs_expr=parse_causaleffect(_extract(element, 'rhs.expr')),
             lhs_cfactor=parse_causaleffect(_extract(element, 'lhs.cfactor')),

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -7,14 +7,13 @@ from __future__ import annotations
 import logging
 from typing import Iterable, NamedTuple, Sequence, Tuple, Union
 
-from ananke.graphs import ADMG
 from rpy2 import robjects
 from rpy2.robjects.packages import importr, isinstalled
 from rpy2.robjects.vectors import StrVector
 
 from y0.dsl import Expression, Variable
 from y0.examples import verma_1
-from y0.graph import NxMixedGraph
+from y0.graph import CausalEffectGraph, NxMixedGraph
 from y0.parser import parse_causaleffect
 
 logger = logging.getLogger(__name__)
@@ -90,7 +89,7 @@ def _extract(element, key):
     return element.rx(key)[0][0]
 
 
-def r_get_verma_constraints(graph: Union[NxMixedGraph, ADMG]) -> Sequence[VermaConstraint]:
+def r_get_verma_constraints(graph: Union[NxMixedGraph, CausalEffectGraph]) -> Sequence[VermaConstraint]:
     """Calculate the verma constraints on the graph using ``causaleffect``."""
     if isinstance(graph, NxMixedGraph):
         graph = graph.to_causaleffect()

--- a/src/y0/causaleffect.py
+++ b/src/y0/causaleffect.py
@@ -5,13 +5,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable, NamedTuple, Sequence
+from typing import Iterable, NamedTuple, Sequence, Tuple
 
 from rpy2 import robjects
 from rpy2.robjects.packages import importr, isinstalled
 from rpy2.robjects.vectors import StrVector
 
-from y0.dsl import Expression
+from y0.dsl import Expression, Variable
 from y0.graph import NxMixedGraph, figure_1
 from y0.parser import parse_causaleffect
 
@@ -56,7 +56,7 @@ class VermaConstraint(NamedTuple):
     lhs_expr: Expression
     rhs_cfactor: str
     rhs_expr: Expression
-    variables: str  # TODO should be a list of variables. What is the delimiter? need example with multiple
+    variables: Tuple[Variable, ...]
 
     @classmethod
     def from_element(cls, element) -> VermaConstraint:
@@ -72,12 +72,16 @@ class VermaConstraint(NamedTuple):
             rhs_expr=parse_causaleffect(_extract(element, 'rhs.expr')),
             lhs_cfactor=_extract(element, 'lhs.cfactor'),
             lhs_expr=parse_causaleffect(_extract(element, 'lhs.expr')),
-            variables=_parse_vars(_extract(element, 'vars')),
+            variables=_parse_vars(element),
         )
 
 
-def _parse_vars(variables: str) -> str:
-    return variables  # TODO
+def _parse_vars(element) -> Tuple[Variable, ...]:
+    _vars = element.rx('vars')
+    return tuple(
+        Variable(name)
+        for name in sorted(_vars[0])
+    )
 
 
 def _extract(element, key):

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -2,6 +2,8 @@
 
 """Graph data structures."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 import networkx as nx
@@ -52,6 +54,21 @@ class NxMixedGraph:
         bi_edges = list(self.undirected.edges())
         vertices = list(self.directed)  # could be either since they're maintained together
         return ADMG(vertices=vertices, di_edges=di_edges, bi_edges=bi_edges)
+
+    def to_causaleffect(self):
+        """Get a causaleffect R object.
+
+        :returns: A causaleffect R object.
+
+        .. warning:: Appropriate R imports need to be done first for 'causaleffect' and 'igraph'.
+        """
+        import rpy2.robjects
+        return rpy2.robjects.r(self.to_causaleffect_str())
+
+    @classmethod
+    def from_causaleffect(cls, graph) -> NxMixedGraph:
+        """Construct an instance from a causaleffect R graph."""
+        raise NotImplementedError
 
     def to_causaleffect_str(self) -> str:
         """Get a string to be imported by R."""

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -53,6 +53,31 @@ class NxMixedGraph:
         vertices = list(self.directed)  # could be either since they're maintained together
         return ADMG(vertices=vertices, di_edges=di_edges, bi_edges=bi_edges)
 
+    def to_causaleffect_str(self) -> str:
+        """Get a string to be imported by R."""
+        if not self.directed:
+            raise ValueError('graph must have some directed edges')
+
+        formula = ', '.join(
+            f'{u} -+ {v}'
+            for u, v in self.directed.edges()
+        )
+        if self.undirected:
+            formula += ''.join(
+                f', {u} -+ {v}, {v} -+ {u}'
+                for u, v in self.undirected.edges()
+            )
+
+        rv = f'g <- graph.formula({formula}, simplify = FALSE)'
+        for i in range(self.undirected.number_of_edges()):
+            idx = 2 * i + self.directed.number_of_edges() + 1
+            rv += (
+                f'\ng <- set.edge.attribute(graph = g, name = "description",'
+                f' index = c({idx}, {idx + 1}), value = "U")'
+            )
+
+        return rv
+
 
 napkin_graph = NxMixedGraph()
 napkin_graph.add_directed_edge('W', 'R')

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -87,3 +87,10 @@ napkin_graph.add_directed_edge('W', 'V1')
 napkin_graph.add_directed_edge('V1', 'Y')
 napkin_graph.add_undirected_edge('W', 'X')
 napkin_graph.add_undirected_edge('W', 'Y')
+
+# Figure 1A from https://arxiv.org/abs/1301.0608
+figure_1 = NxMixedGraph()
+figure_1.add_directed_edge('A', 'B')
+figure_1.add_directed_edge('B', 'C')
+figure_1.add_directed_edge('C', 'D')
+figure_1.add_undirected_edge('B', 'D')

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -5,16 +5,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Collection, Generic, Iterable, Mapping, Optional, Tuple, TypeVar
+from typing import Any, Collection, Generic, Iterable, Mapping, Optional, Tuple, TypeVar
 
 import networkx as nx
 from ananke.graphs import ADMG
 
 __all__ = [
     'NxMixedGraph',
+    'CausalEffectGraph',
 ]
 
 X = TypeVar('X')
+CausalEffectGraph = Any
 
 
 @dataclass
@@ -57,7 +59,7 @@ class NxMixedGraph(Generic[X]):
         vertices = list(self.directed)  # could be either since they're maintained together
         return ADMG(vertices=vertices, di_edges=di_edges, bi_edges=bi_edges)
 
-    def to_causaleffect(self):
+    def to_causaleffect(self) -> CausalEffectGraph:
         """Get a causaleffect R object.
 
         :returns: A causaleffect R object.

--- a/src/y0/parser/__init__.py
+++ b/src/y0/parser/__init__.py
@@ -2,5 +2,6 @@
 
 """Parsers for various probability expression grammars."""
 
+from .ce.grammar import parse_causaleffect  # noqa:F401
 from .craig.grammar import parse_craig  # noqa:F401
 from .internal import parse_y0  # noqa:F401

--- a/src/y0/parser/ce/__init__.py
+++ b/src/y0/parser/ce/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""A parser for causaleffect probability expressions based on :mod:`pyparsing`."""

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -1,14 +1,80 @@
 # -*- coding: utf-8 -*-
 
-"""A parser for causaleffect probability expressions based on :mod:`pyparsing`."""
+"""A parser for Craig-like probability expressions based on :mod:`pyparsing`."""
 
-from ...dsl import Expression
+from pyparsing import Forward, Group, OneOrMore, Optional, ParseResults, StringEnd, StringStart, Suppress
+
+from .utils import probability_pe, variables_pe
+from ...dsl import Expression, Fraction, Product, Sum
 
 __all__ = [
     'parse_causaleffect',
+    'grammar',
 ]
+
+expr = Forward()
+
+
+def _make_sum(_s, _l, tokens: ParseResults) -> Sum:
+    return Sum(
+        ranges=tuple(tokens['ranges'].asList()) if 'ranges' in tokens else tuple(),
+        expression=tokens['expression'],
+    )
+
+
+def _make_frac(_s, _l, tokens: ParseResults) -> Fraction:
+    return Fraction(
+        numerator=tokens['numerator'],
+        denominator=tokens['denominator'],
+    )
+
+
+def _make_product(_s, _l, tokens: ParseResults) -> Expression:
+    tokens = tokens.asList()
+    if len(tokens) == 1:
+        return tokens[0]
+    else:
+        return Product(tuple(tokens))
+
+
+# auto-product
+rr = OneOrMore(probability_pe | expr).setParseAction(_make_product)
+
+sum_pe = (
+    Suppress(r'\\sum_{')
+    + Optional(Group(variables_pe).setResultsName('ranges'))
+    + Suppress('}')
+    + rr.setResultsName('expression')
+)
+sum_pe.setName('sum')
+sum_pe.setParseAction(_make_sum)
+
+fraction_pe = (
+    Suppress(r'\\frac_{')
+    + rr.setResultsName('numerator')
+    + Suppress('}{')
+    + rr.setResultsName('denominator')
+    + Suppress('}')
+)
+fraction_pe.setName('fraction')
+fraction_pe.setParseAction(_make_frac)
+
+expr << (probability_pe | sum_pe | fraction_pe)
+
+# TODO enable products?
+
+grammar = StringStart() + expr + StringEnd()
+grammar.setName('probabilityGrammar')
 
 
 def parse_causaleffect(s: str) -> Expression:
     """Parse a causaleffect probability expression."""
-    raise NotImplementedError
+    x = grammar.parseString(s)
+    return x.asList()[0]
+
+
+if __name__ == '__main__':
+    print(variables_pe.parseString('u'))
+    print(variables_pe.parseString('u_{0}'))
+    print(probability_pe.parseString('P(u_{0})')[0])
+    print(probability_pe.parseString('P(D|u_{1},C)')[0])

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -82,11 +82,3 @@ def parse_causaleffect(s: str) -> Expression:
         raise
     else:
         return x.asList()[0]
-
-
-if __name__ == '__main__':
-    print(variables_pe.parseString('u'))
-    print(variables_pe.parseString('V3'))
-    print(variables_pe.parseString('u_{0}'))
-    print(probability_pe.parseString('P(u_{0})')[0])
-    print(probability_pe.parseString('P(D|u_{1},C)')[0])

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -2,6 +2,9 @@
 
 """A parser for Craig-like probability expressions based on :mod:`pyparsing`."""
 
+import logging
+
+import pyparsing
 from pyparsing import Forward, Group, OneOrMore, Optional, ParseResults, StringEnd, StringStart, Suppress
 
 from .utils import probability_pe, variables_pe
@@ -12,6 +15,7 @@ __all__ = [
     'grammar',
 ]
 
+logger = logging.getLogger(__name__)
 expr = Forward()
 
 
@@ -41,7 +45,7 @@ def _make_product(_s, _l, tokens: ParseResults) -> Expression:
 rr = OneOrMore(probability_pe | expr).setParseAction(_make_product)
 
 sum_pe = (
-    Suppress(r'\\sum_{')
+    Suppress('\\sum_{')
     + Optional(Group(variables_pe).setResultsName('ranges'))
     + Suppress('}')
     + rr.setResultsName('expression')
@@ -50,7 +54,7 @@ sum_pe.setName('sum')
 sum_pe.setParseAction(_make_sum)
 
 fraction_pe = (
-    Suppress(r'\\frac_{')
+    Suppress('\\frac_{')
     + rr.setResultsName('numerator')
     + Suppress('}{')
     + rr.setResultsName('denominator')

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -9,8 +9,8 @@ from pyparsing import (
     Suppress,
 )
 
-from y0.dsl import Expression, Fraction, Product, Sum
-from y0.parser.ce.utils import probability_pe, qfactor_pe, variables_pe
+from .utils import probability_pe, qfactor_pe, variables_pe
+from ...dsl import Expression, Fraction, Product, Sum
 
 __all__ = [
     'parse_causaleffect',

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+"""A parser for causaleffect probability expressions based on :mod:`pyparsing`."""
+
+from ...dsl import Expression
+
+__all__ = [
+    'parse_causaleffect',
+]
+
+
+def parse_causaleffect(s: str) -> Expression:
+    """Parse a causaleffect probability expression."""
+    raise NotImplementedError

--- a/src/y0/parser/ce/utils.py
+++ b/src/y0/parser/ce/utils.py
@@ -2,10 +2,10 @@
 
 """A parser for causaleffect probability expressions based on :mod:`pyparsing`."""
 
-from pyparsing import Group, Optional, ParseResults, Suppress, Word, delimitedList, nums
+from pyparsing import Group, Optional, ParseResults, Suppress, Word, alphanums, alphas, delimitedList, nums
 
 from y0.dsl import Variable
-from y0.parser.craig.utils import _make_probability, _unpack, letter
+from y0.parser.craig.utils import _make_probability, _make_q, _unpack
 
 
 def _make_variable(_s, _l, tokens: ParseResults) -> Variable:
@@ -16,7 +16,7 @@ def _make_variable(_s, _l, tokens: ParseResults) -> Variable:
 
 
 subscript = Suppress('_{') + Word(nums)('subscript') + Suppress('}')
-variable_pe = letter('name') + Optional(subscript)
+variable_pe = Word(alphas, alphanums)('name') + Optional(subscript)
 variable_pe.setParseAction(_make_variable)
 variable_pe.setName('variable')
 
@@ -26,3 +26,13 @@ _parents_pe = Group(Optional(Suppress('|') + variables_pe)).setResultsName('pare
 probability_pe = Suppress('P(') + _children_pe + _parents_pe + Suppress(')')
 probability_pe.setParseAction(_make_probability)
 probability_pe.setName('probability')
+
+qfactor_pe = (
+    Suppress('Q[\\{')
+    + Group(variables_pe).setResultsName('codomain')
+    + Suppress('\\}](')
+    + Group(variables_pe).setResultsName('domain')
+    + Suppress(')')
+)
+qfactor_pe.setParseAction(_make_q)
+qfactor_pe.setName('qfactor')

--- a/src/y0/parser/ce/utils.py
+++ b/src/y0/parser/ce/utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+"""A parser for causaleffect probability expressions based on :mod:`pyparsing`."""
+
+from pyparsing import Group, Optional, ParseResults, Suppress, Word, delimitedList, nums
+
+from y0.dsl import Variable
+from y0.parser.craig.utils import _make_probability, _unpack, letter
+
+
+def _make_variable(_s, _l, tokens: ParseResults) -> Variable:
+    name = tokens['name']
+    if 'subscript' in tokens:
+        name += ('_' + tokens['subscript'])
+    return Variable(name=name)
+
+
+subscript = Suppress('_{') + Word(nums)('subscript') + Suppress('}')
+variable_pe = letter('name') + Optional(subscript)
+variable_pe.setParseAction(_make_variable)
+variable_pe.setName('variable')
+
+variables_pe = delimitedList(Group(variable_pe).setParseAction(_unpack))
+_children_pe = Group(variables_pe).setResultsName('children')
+_parents_pe = Group(Optional(Suppress('|') + variables_pe)).setResultsName('parents')
+probability_pe = Suppress('P(') + _children_pe + _parents_pe + Suppress(')')
+probability_pe.setParseAction(_make_probability)
+probability_pe.setName('probability')

--- a/src/y0/parser/ce/utils.py
+++ b/src/y0/parser/ce/utils.py
@@ -4,8 +4,8 @@
 
 from pyparsing import Group, Optional, ParseResults, Suppress, Word, alphanums, alphas, delimitedList, nums
 
-from y0.dsl import Variable
-from y0.parser.craig.utils import _make_probability, _make_q, _unpack
+from ..craig.utils import _make_probability, _make_q, _unpack
+from ...dsl import Variable
 
 
 def _make_variable(_s, _l, tokens: ParseResults) -> Variable:

--- a/src/y0/r_utils.py
+++ b/src/y0/r_utils.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+"""General utilities for :mod:`rpy2`."""
+
+import logging
+from functools import lru_cache, wraps
+from typing import Iterable
+
+from rpy2.robjects.packages import importr, isinstalled
+from rpy2.robjects.vectors import StrVector
+
+__all__ = [
+    'uses_r',
+]
+
+logger = logging.getLogger(__name__)
+
+CAUSALEFFECT = 'causaleffect'
+IGRAPH = 'igraph'
+R_REQUIREMENTS = [
+    CAUSALEFFECT,
+    IGRAPH,
+]
+
+
+def prepare_renv(requirements: Iterable[str]) -> None:
+    """Ensure the given R packages are installed.
+
+    :param requirements: A list of R packages to ensure are installed
+
+    .. seealso:: https://rpy2.github.io/doc/v3.4.x/html/introduction.html#installing-packages
+    """
+    # import R's utility package
+    utils = importr('utils')
+
+    # select a mirror for R packages
+    utils.chooseCRANmirror(ind=1)  # select the first mirror in the list
+
+    uninstalled_requirements = [
+        requirement
+        for requirement in requirements
+        if not isinstalled(requirement)
+    ]
+    if uninstalled_requirements:
+        logger.warning('installing R packages: %s', uninstalled_requirements)
+        utils.install_packages(StrVector(uninstalled_requirements))
+
+    for requirement in requirements:
+        importr(requirement)
+
+
+@lru_cache(maxsize=1)
+def prepare_default_renv() -> bool:
+    """Prepare the default R environment."""
+    prepare_renv(R_REQUIREMENTS)
+    return True
+
+
+def uses_r(f):
+    """Decorate functions that use R."""
+
+    @wraps(f)
+    def _wrapped(*args, **kwargs):
+        prepare_default_renv()
+        return f(*args, **kwargs)
+
+    return _wrapped

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -37,10 +37,10 @@ class TestCausalEffect(unittest.TestCase):
         self.assertEqual(1, len(actual))
         self.assertEqual(
             VermaConstraint(
-                rhs_cfactor=parse_causaleffect("Q[\\{D\\}](C,D)"),
-                rhs_expr=parse_causaleffect("\\sum_{u_{1},C}P(D|u_{1},C)P(C)P(u_{1})"),
-                lhs_cfactor=parse_causaleffect("\\sum_{B}Q[\\{B,D\\}](A,B,C,D)"),
-                lhs_expr=parse_causaleffect("\\sum_{B}P(D|A,B,C)P(B|A)"),
+                rhs_cfactor=r"Q[\\{D\\}](C,D)",
+                rhs_expr=parse_causaleffect(r"\\sum_{u_{1},C}P(D|u_{1},C)P(C)P(u_{1})"),
+                lhs_cfactor=r"\\sum_{B}Q[\\{B,D\\}](A,B,C,D)",
+                lhs_expr=parse_causaleffect(r"\\sum_{B}P(D|A,B,C)P(B|A)"),
                 variables="A",
             ),
             actual[0],

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -4,8 +4,8 @@
 
 import unittest
 
+from y0.dsl import A, B, C, D, P, Sum, Variable
 from y0.graph import figure_1
-from y0.parser import parse_causaleffect
 
 try:
     from y0.causaleffect import CAUSALEFFECT, IGRAPH, VermaConstraint, r_get_verma_constraints
@@ -13,6 +13,8 @@ except ImportError:  # rpy2 is not installed
     missing_rpy2 = True
 else:
     missing_rpy2 = False
+
+u_1 = Variable('u_1')
 
 
 @unittest.skipIf(missing_rpy2, 'rpy2 is not installed')
@@ -35,13 +37,16 @@ class TestCausalEffect(unittest.TestCase):
         """Test getting the single Verma constraint from the Figure 1A graph."""
         actual = r_get_verma_constraints(figure_1)
         self.assertEqual(1, len(actual))
+        verma_constraint = actual[0]
+        self.assertIsInstance(verma_constraint, VermaConstraint)
+        self.assertEqual("Q[\\{D\\}](C,D)", verma_constraint.rhs_cfactor)
+
+        expected_rhs_expr = Sum[u_1, C](P(D | u_1 | C) * P(C) * P(u_1))
         self.assertEqual(
-            VermaConstraint(
-                rhs_cfactor=r"Q[\\{D\\}](C,D)",
-                rhs_expr=parse_causaleffect(r"\\sum_{u_{1},C}P(D|u_{1},C)P(C)P(u_{1})"),
-                lhs_cfactor=r"\\sum_{B}Q[\\{B,D\\}](A,B,C,D)",
-                lhs_expr=parse_causaleffect(r"\\sum_{B}P(D|A,B,C)P(B|A)"),
-                variables="A",
-            ),
-            actual[0],
+            expected_rhs_expr,
+            verma_constraint.rhs_expr,
+            msg=f'Expected: {expected_rhs_expr}\nActual:  {verma_constraint.rhs_expr}'
         )
+        self.assertEqual("\\sum_{B}Q[\\{B,D\\}](A,B,C,D)", verma_constraint.lhs_cfactor)
+        self.assertEqual(Sum[B](P(D | (A, B, C)) * P(B | A)), verma_constraint.lhs_expr)
+        self.assertEqual((A,), verma_constraint.variables)

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -49,7 +49,7 @@ class TestCausalEffect(unittest.TestCase):
         self.assertEqual(
             expected_rhs_expr,
             verma_constraint.rhs_expr,
-            msg=f'Expected: {expected_rhs_expr}\nActual:  {verma_constraint.rhs_expr}'
+            msg=f'Expected: {expected_rhs_expr}\nActual:  {verma_constraint.rhs_expr}',
         )
         self.assertEqual(Sum[V2](Q[V2, V4](V1, V2, V3, V4)), verma_constraint.lhs_cfactor)
         self.assertEqual(Sum[V2](P(V4 | (V1, V2, V3)) * P(V2 | V1)), verma_constraint.lhs_expr)

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for the CausalEffect wrapper."""
+
+import unittest
+
+from y0.graph import figure_1
+
+try:
+    from y0.causaleffect import CAUSALEFFECT, IGRAPH, VermaConstraint, r_get_verma_constraints
+except ImportError:  # rpy2 is not installed
+    missing_rpy2 = True
+else:
+    missing_rpy2 = False
+
+
+@unittest.skipIf(missing_rpy2, 'rpy2 is not installed')
+class TestCausalEffect(unittest.TestCase):
+    """Tests for the causaleffect wrapper."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Make imports for the class."""
+        from rpy2.robjects.packages import importr
+        from rpy2.robjects.packages import PackageNotInstalledError
+
+        try:
+            importr(CAUSALEFFECT)
+            importr(IGRAPH)
+        except PackageNotInstalledError:
+            raise unittest.SkipTest('R packages not properly installed.')
+
+    def test_verma_constraint(self):
+        """Test getting the single Verma constraint from the Figure 1A graph."""
+        actual = r_get_verma_constraints(figure_1)
+        self.assertEqual(1, len(actual))
+        self.assertEqual(
+            VermaConstraint(
+                rhs_cfactor="Q[\\{D\\}](C,D)",
+                rhs_expr="\\sum_{u_{1},C}P(D|u_{1},C)P(C)P(u_{1})",
+                lhs_cfactor="\\sum_{B}Q[\\{B,D\\}](A,B,C,D)",
+                lhs_expr="\\sum_{B}P(D|A,B,C)P(B|A)",
+                variables="A",
+            ),
+            actual[0],
+        )

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -5,7 +5,7 @@
 import unittest
 
 from y0.dsl import A, B, C, D, P, Sum, Variable
-from y0.graph import figure_1
+from y0.examples import verma_1
 
 try:
     from y0.causaleffect import CAUSALEFFECT, IGRAPH, VermaConstraint, r_get_verma_constraints
@@ -35,7 +35,7 @@ class TestCausalEffect(unittest.TestCase):
 
     def test_verma_constraint(self):
         """Test getting the single Verma constraint from the Figure 1A graph."""
-        actual = r_get_verma_constraints(figure_1)
+        actual = r_get_verma_constraints(verma_1)
         self.assertEqual(1, len(actual))
         verma_constraint = actual[0]
         self.assertIsInstance(verma_constraint, VermaConstraint)

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -8,7 +8,8 @@ from y0.dsl import P, Q, Sum, Variable
 from y0.examples import verma_1
 
 try:
-    from y0.causaleffect import CAUSALEFFECT, IGRAPH, VermaConstraint, r_get_verma_constraints
+    from y0.causaleffect import VermaConstraint, r_get_verma_constraints
+    from y0.r_utils import CAUSALEFFECT, IGRAPH
 except ImportError:  # rpy2 is not installed
     missing_rpy2 = True
 else:

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -5,6 +5,7 @@
 import unittest
 
 from y0.graph import figure_1
+from y0.parser import parse_causaleffect
 
 try:
     from y0.causaleffect import CAUSALEFFECT, IGRAPH, VermaConstraint, r_get_verma_constraints
@@ -36,10 +37,10 @@ class TestCausalEffect(unittest.TestCase):
         self.assertEqual(1, len(actual))
         self.assertEqual(
             VermaConstraint(
-                rhs_cfactor="Q[\\{D\\}](C,D)",
-                rhs_expr="\\sum_{u_{1},C}P(D|u_{1},C)P(C)P(u_{1})",
-                lhs_cfactor="\\sum_{B}Q[\\{B,D\\}](A,B,C,D)",
-                lhs_expr="\\sum_{B}P(D|A,B,C)P(B|A)",
+                rhs_cfactor=parse_causaleffect("Q[\\{D\\}](C,D)"),
+                rhs_expr=parse_causaleffect("\\sum_{u_{1},C}P(D|u_{1},C)P(C)P(u_{1})"),
+                lhs_cfactor=parse_causaleffect("\\sum_{B}Q[\\{B,D\\}](A,B,C,D)"),
+                lhs_expr=parse_causaleffect("\\sum_{B}P(D|A,B,C)P(B|A)"),
                 variables="A",
             ),
             actual[0],

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from y0.dsl import A, B, C, D, P, Q, Sum, Variable
+from y0.dsl import P, Q, Sum, Variable
 from y0.examples import verma_1
 
 try:
@@ -15,6 +15,10 @@ else:
     missing_rpy2 = False
 
 u_1 = Variable('u_1')
+V1 = Variable('V1')
+V2 = Variable('V2')
+V3 = Variable('V3')
+V4 = Variable('V4')
 
 
 @unittest.skipIf(missing_rpy2, 'rpy2 is not installed')
@@ -39,14 +43,14 @@ class TestCausalEffect(unittest.TestCase):
         self.assertEqual(1, len(actual))
         verma_constraint = actual[0]
         self.assertIsInstance(verma_constraint, VermaConstraint)
-        self.assertEqual(Q[D](C, D), verma_constraint.rhs_cfactor)
+        self.assertEqual(Q[V4](V3, V4), verma_constraint.rhs_cfactor)
 
-        expected_rhs_expr = Sum[u_1, C](P(D | u_1 | C) * P(C) * P(u_1))
+        expected_rhs_expr = Sum[u_1, V3](P(V4 | u_1 | V3) * P(V3) * P(u_1))
         self.assertEqual(
             expected_rhs_expr,
             verma_constraint.rhs_expr,
             msg=f'Expected: {expected_rhs_expr}\nActual:  {verma_constraint.rhs_expr}'
         )
-        self.assertEqual(Sum[B](Q[B, D](A, B, C, D)), verma_constraint.lhs_cfactor)
-        self.assertEqual(Sum[B](P(D | (A, B, C)) * P(B | A)), verma_constraint.lhs_expr)
-        self.assertEqual((A,), verma_constraint.variables)
+        self.assertEqual(Sum[V2](Q[V2, V4](V1, V2, V3, V4)), verma_constraint.lhs_cfactor)
+        self.assertEqual(Sum[V2](P(V4 | (V1, V2, V3)) * P(V2 | V1)), verma_constraint.lhs_expr)
+        self.assertEqual((V1,), verma_constraint.variables)

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-from y0.dsl import A, B, C, D, P, Sum, Variable
+from y0.dsl import A, B, C, D, P, Q, Sum, Variable
 from y0.examples import verma_1
 
 try:
@@ -39,7 +39,7 @@ class TestCausalEffect(unittest.TestCase):
         self.assertEqual(1, len(actual))
         verma_constraint = actual[0]
         self.assertIsInstance(verma_constraint, VermaConstraint)
-        self.assertEqual("Q[\\{D\\}](C,D)", verma_constraint.rhs_cfactor)
+        self.assertEqual(Q[D](C, D), verma_constraint.rhs_cfactor)
 
         expected_rhs_expr = Sum[u_1, C](P(D | u_1 | C) * P(C) * P(u_1))
         self.assertEqual(
@@ -47,6 +47,6 @@ class TestCausalEffect(unittest.TestCase):
             verma_constraint.rhs_expr,
             msg=f'Expected: {expected_rhs_expr}\nActual:  {verma_constraint.rhs_expr}'
         )
-        self.assertEqual("\\sum_{B}Q[\\{B,D\\}](A,B,C,D)", verma_constraint.lhs_cfactor)
+        self.assertEqual(Sum[B](Q[B, D](A, B, C, D)), verma_constraint.lhs_cfactor)
         self.assertEqual(Sum[B](P(D | (A, B, C)) * P(B | A)), verma_constraint.lhs_expr)
         self.assertEqual((A,), verma_constraint.variables)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""Test graph construction and conversion."""
+
+import unittest
+from textwrap import dedent
+
+from y0.graph import napkin_graph
+
+
+class TestGraph(unittest.TestCase):
+    """Test graph construction and conversion."""
+
+    def test_causaleffect_str_napkin(self):
+        """Test generating R code for the napkin graph for causaleffect."""
+        expected = dedent('''
+        g <- graph.formula(W -+ R, W -+ V1, R -+ X, X -+ Y, V1 -+ Y, W -+ X, X -+ W, W -+ Y, Y -+ W, simplify = FALSE)
+        g <- set.edge.attribute(graph = g, name = "description", index = c(6, 7), value = "U")
+        g <- set.edge.attribute(graph = g, name = "description", index = c(8, 9), value = "U")
+        ''').strip()
+        self.assertEqual(expected, napkin_graph.to_causaleffect_str())

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,11 +5,18 @@
 import unittest
 from textwrap import dedent
 
-from y0.graph import napkin_graph
+from y0.graph import figure_1, napkin_graph
 
 
 class TestGraph(unittest.TestCase):
     """Test graph construction and conversion."""
+
+    def test_causaleffect_str_figure_1a(self):
+        expected = dedent('''
+        g <- graph.formula(A -+ B, B -+ C, C -+ D, B -+ D, D -+ B, simplify = FALSE)
+        g <- set.edge.attribute(graph = g, name = "description", index = c(4, 5), value = "U")
+        ''').strip()
+        self.assertEqual(expected, figure_1.to_causaleffect_str())
 
     def test_causaleffect_str_napkin(self):
         """Test generating R code for the napkin graph for causaleffect."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,25 +5,16 @@
 import unittest
 from textwrap import dedent
 
-from y0.graph import figure_1, napkin_graph
+from y0.examples import verma_1
 
 
 class TestGraph(unittest.TestCase):
     """Test graph construction and conversion."""
 
-    def test_causaleffect_str_figure_1a(self):
+    def test_causaleffect_str_verma_1(self):
         """Test generating R code for the figure 1A graph for causaleffect."""
         expected = dedent('''
-        g <- graph.formula(A -+ B, B -+ C, C -+ D, B -+ D, D -+ B, simplify = FALSE)
+        g <- graph.formula(V1 -+ V2, V2 -+ V3, V3 -+ V4, V2 -+ V4, V4 -+ V2, simplify = FALSE)
         g <- set.edge.attribute(graph = g, name = "description", index = c(4, 5), value = "U")
         ''').strip()
-        self.assertEqual(expected, figure_1.to_causaleffect_str())
-
-    def test_causaleffect_str_napkin(self):
-        """Test generating R code for the napkin graph for causaleffect."""
-        expected = dedent('''
-        g <- graph.formula(W -+ R, W -+ V1, R -+ X, X -+ Y, V1 -+ Y, W -+ X, X -+ W, W -+ Y, Y -+ W, simplify = FALSE)
-        g <- set.edge.attribute(graph = g, name = "description", index = c(6, 7), value = "U")
-        g <- set.edge.attribute(graph = g, name = "description", index = c(8, 9), value = "U")
-        ''').strip()
-        self.assertEqual(expected, napkin_graph.to_causaleffect_str())
+        self.assertEqual(expected, verma_1.to_causaleffect_str())

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -12,6 +12,7 @@ class TestGraph(unittest.TestCase):
     """Test graph construction and conversion."""
 
     def test_causaleffect_str_figure_1a(self):
+        """Test generating R code for the figure 1A graph for causaleffect."""
         expected = dedent('''
         g <- graph.formula(A -+ B, B -+ C, C -+ D, B -+ D, D -+ B, simplify = FALSE)
         g <- set.edge.attribute(graph = g, name = "description", index = c(4, 5), value = "U")

--- a/tests/test_parser/test_causaleffect.py
+++ b/tests/test_parser/test_causaleffect.py
@@ -17,7 +17,7 @@ class TestCausaleffectGrammar(unittest.TestCase):
     def test_sum(self):
         """Test the sum grammar."""
         for expr, s in [
-            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), r"\\sum_{U_{1},C}P(D|U_{1},C)P(C)P(U_{1})"),
+            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), r"\sum_{U_{1},C}P(D|U_{1},C)P(C)P(U_{1})"),
         ]:
             with self.subTest(s=s):
                 parse_result = sum_pe.parseString(s)
@@ -31,7 +31,7 @@ class TestCausaleffectGrammar(unittest.TestCase):
     def test_parse(self):
         """Test the high-level parser API."""
         for expr, s in [
-            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), r"\\sum_{U_{1},C}P(D|U_{1},C)P(C)P(U_{1})"),
+            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), r"\sum_{U_{1},C}P(D|U_{1},C)P(C)P(U_{1})"),
         ]:
             with self.subTest(s=s):
                 actual = parse_causaleffect(s)

--- a/tests/test_parser/test_causaleffect.py
+++ b/tests/test_parser/test_causaleffect.py
@@ -6,6 +6,7 @@ import unittest
 
 from y0.dsl import C, D, P, Sum, Variable
 from y0.parser import parse_causaleffect
+from y0.parser.ce.grammar import sum_pe
 
 U_1 = Variable('U_1')
 
@@ -13,10 +14,24 @@ U_1 = Variable('U_1')
 class TestCausaleffectGrammar(unittest.TestCase):
     """Tests for parsing causaleffect probability expressions."""
 
+    def test_sum(self):
+        """Test the sum grammar."""
+        for expr, s in [
+            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), r"\\sum_{U_{1},C}P(D|U_{1},C)P(C)P(U_{1})"),
+        ]:
+            with self.subTest(s=s):
+                parse_result = sum_pe.parseString(s)
+                result_expression = parse_result.asList()[0]
+                self.assertIsInstance(result_expression, Sum)
+                self.assertEqual(
+                    expr, result_expression,
+                    msg=f'Mismatch\nExpected: {repr(expr)}\nActual:   {repr(result_expression)}',
+                )
+
     def test_parse(self):
         """Test the high-level parser API."""
         for expr, s in [
-            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), "\\sum_{U_{1},C}P(D|u_{1},C)P(C)P(U_{1})"),
+            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), r"\\sum_{U_{1},C}P(D|U_{1},C)P(C)P(U_{1})"),
         ]:
             with self.subTest(s=s):
                 actual = parse_causaleffect(s)

--- a/tests/test_parser/test_causaleffect.py
+++ b/tests/test_parser/test_causaleffect.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+"""Test the causaleffect probability expression parser."""
+
+import unittest
+
+from y0.dsl import C, D, P, Sum, Variable
+from y0.parser import parse_causaleffect
+
+U_1 = Variable('U_1')
+
+
+class TestCausaleffectGrammar(unittest.TestCase):
+    """Tests for parsing causaleffect probability expressions."""
+
+    def test_parse(self):
+        """Test the high-level parser API."""
+        for expr, s in [
+            (Sum[U_1, C](P(D | U_1 | C) * P(C) * P(U_1)), "\\sum_{U_{1},C}P(D|u_{1},C)P(C)P(U_{1})"),
+        ]:
+            with self.subTest(s=s):
+                actual = parse_causaleffect(s)
+                self.assertEqual(expr, actual, msg=f'\nExpected: {expr}\nActual:   {actual}')

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ commands = pytest --durations=20 {posargs:tests} --cov=./ --cov-report=xml
 deps =
     pytest
     pytest-cov
+extras =
+    r
 
 [testenv:coverage-clean]
 deps = coverage


### PR DESCRIPTION
This PR does the following:

- [x] Implements conversion from the `y0` graph builder into a string R code that would create the same graph (0d5be45)
- [x] Wraps the application of the `verma.constraint` function (7d8c7f2)
- [x] Implements a parser for causaleffect's internal probability expression grammar (closes #13)
    - [x] Still need to understand what the Q term means in the cfactor expressions from the `verma.constraint` function

Maybe also in this PR (later):
- [ ] ~Wraps the application of the `simplify` function~
- [ ] ~Converter from y0 DSL objects into input for the simplify function~