### PR TITLE
More examples and automation of testing

### DIFF
--- a/src/y0/examples.py
+++ b/src/y0/examples.py
@@ -3,10 +3,12 @@
 
 """Examples from CausalFusion."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
-from .dsl import P, Q, Sum, Variable, X, Y, Z1, Z2
+from .dsl import P, Q, Sum, Variable, X, Y, Z1, Z2, Z3, Z4, Z5
 from .graph import NxMixedGraph
 from .struct import ConditionalIndependency, VermaConstraint
 
@@ -16,17 +18,18 @@ class Example:
     """An example graph packaged with certain pre-calculated data structures."""
 
     name: str
+    reference: str
     graph: NxMixedGraph
     verma_constraints: Optional[Sequence[VermaConstraint]] = None
     conditional_independencies: Optional[Sequence[ConditionalIndependency]] = None
 
 
 u_2 = Variable('u_2')
+u_3 = Variable('u_3')
 
 #: Treatment: X
 #: Outcome: Y
 #: Adjusted: N/A
-#: Reference: J. Pearl. 2009. "Causality: Models, Reasoning and Inference. 2nd ed." Cambridge University Press, p. 178.
 backdoor = NxMixedGraph.from_edges(directed=[
     ('Z', 'X'),
     ('Z', 'Y'),
@@ -35,13 +38,14 @@ backdoor = NxMixedGraph.from_edges(directed=[
 
 backdoor_example = Example(
     name='Backdoor',
+    reference='J. Pearl. 2009. "Causality: Models, Reasoning and Inference.'
+              ' 2nd ed." Cambridge University Press, p. 178.',
     graph=backdoor,
 )
 
 #: Treatment: X
 #: Outcome: Y
 #: Adjusted: N/A
-#: Reference: J. Pearl. 2009. "Causality: Models, Reasoning and Inference. 2nd ed." Cambridge University Press, p. 81.
 frontdoor = NxMixedGraph.from_edges(
     directed=[
         ('X', 'Z'),
@@ -53,12 +57,13 @@ frontdoor = NxMixedGraph.from_edges(
 )
 frontdoor_example = Example(
     name='Frontdoor',
+    reference='J. Pearl. 2009. "Causality: Models, Reasoning and Inference.'
+              ' 2nd ed." Cambridge University Press, p. 81.',
     graph=frontdoor,
 )
 
 #: Treatment: X
 #: Outcome: Y
-#: Reference: J. Pearl. 2009. "Causality: Models, Reasoning and Inference. 2nd ed." Cambridge University Press, p. 153.
 instrumental_variable = NxMixedGraph.from_edges(
     directed=[
         ('Z', 'X'),
@@ -70,13 +75,13 @@ instrumental_variable = NxMixedGraph.from_edges(
 )
 instrumental_variable_example = Example(
     name='Instrument Variable',
+    reference='J. Pearl. 2009. "Causality: Models, Reasoning and Inference.'
+              ' 2nd ed." Cambridge University Press, p. 153.',
     graph=instrumental_variable,
 )
 
 #: Treatment: X
 #: Outcome: Y
-#: Reference: J. Pearl and D. Mackenzie. 2018. "The Book of Why: The New Science of Cause and Effect." Basic Books,
-#   p. 240.
 napkin = NxMixedGraph.from_edges(
     directed=[
         ('Z2', 'Z1'),
@@ -90,6 +95,8 @@ napkin = NxMixedGraph.from_edges(
 )
 napkin_example = Example(
     name='Napkin',
+    reference='J. Pearl and D. Mackenzie. 2018. "The Book of Why: The New Science of Cause and Effect."'
+              ' Basic Books, p. 240.',
     graph=napkin,
     verma_constraints=[
         VermaConstraint(
@@ -107,8 +114,7 @@ napkin_example = Example(
 
 #: Treatment: X
 #: Outcome: Y
-#: Reference: S. Greenland, J. Pearl, and J.M. Robins. 1999. "Causal Diagrams for Epidemiologic Research." Epidemiology
-#: Journal, Volume 10, No. 10, pp. 37-48, 1999.
+#: Reference:
 m_graph = NxMixedGraph.from_edges(
     directed=[
         ('X', 'Y'),
@@ -120,12 +126,13 @@ m_graph = NxMixedGraph.from_edges(
 )
 m_graph_example = Example(
     name='M-Graph',
+    reference='S. Greenland, J. Pearl, and J.M. Robins. 1999. "Causal Diagrams for Epidemiologic Research."'
+              ' Epidemiology Journal, Volume 10, No. 10, pp. 37-48, 1999.',
     graph=m_graph,
 )
 
 #: Treatment: X
 #: Outcome: Y
-#: Reference: J. Pearl. 2009. "Causality: Models, Reasoning and Inference. 2nd ed." Cambridge University Press, p. 80.
 identifiability_1 = NxMixedGraph.from_edges(
     directed=[
         ('Z1', 'Z2'),
@@ -141,6 +148,8 @@ identifiability_1 = NxMixedGraph.from_edges(
 )
 identifiability_1_example = Example(
     name='Identifiability 1',
+    reference='J. Pearl. 2009. "Causality: Models, Reasoning and Inference.'
+              ' 2nd ed." Cambridge University Press, p. 80.',
     graph=identifiability_1,
     conditional_independencies=(
         ConditionalIndependency.create('X', 'Z1', ['Z2', 'Z3']),
@@ -160,7 +169,6 @@ identifiability_1_example = Example(
 
 #: Treatment: X
 #: Outcome: Y
-#: Reference: E. Bareinboim modification of Identifiability 1.
 identifiability_2 = NxMixedGraph.from_edges(
     directed=[
         ('Z1', 'Z2'),
@@ -185,9 +193,29 @@ identifiability_2 = NxMixedGraph.from_edges(
 )
 identifiability_2_example = Example(
     name='Identifiability 2',
+    reference='E. Bareinboim modification of Identifiability 1.',
     graph=identifiability_2,
     verma_constraints=[
-        ...
+        VermaConstraint(
+            rhs_cfactor=Q[Z5](Z4, Z5),
+            rhs_expr=Sum[u_3, Z4](P(Z5 | (u_3, Z4)) * P(Z4) * P(u_3)),
+            lhs_cfactor=Sum[Z3](Q[Z3, Z5](Z1, Z4, Z3, Z5)),
+            lhs_expr=Sum[Z3](P(Z5 | (Z1, Z2, Z3, Z4)) * P(Z3 | (Z1, Z2, Z4))),
+            variables=(Z1,),
+        ),
+        VermaConstraint(
+            rhs_cfactor=Q[Z5](Z4, Z5),
+            rhs_expr=Sum[u_3, Z4](P(Z5 | (u_3, Z4)) * P(Z4) * P(u_3)),
+            lhs_cfactor=(
+                Q[Z2, Z5](Z1, Z4, Z2, Z5)
+                / Sum[Z5](Q[Z2, Z5](Z1, Z4, Z2, Z5))
+            ),
+            lhs_expr=(
+                Sum[Z3](P(Z5 | (Z1, Z2, Z3, Z4)) * P(Z3 | (Z1, Z4, Z2)) * P(Z2 | (Z1, Z4)))
+                / Sum[Z3, Z5](P(Z5 | (Z1, Z4, Z2, Z3)) * P(Z3 | (Z1, Z4, Z2)) * P(Z2 | (Z1, Z4)))
+            ),
+            variables=(Z1, Z2),
+        ),
     ],
     conditional_independencies=[
         ConditionalIndependency.create('W0', 'W1', ['X']),
@@ -217,7 +245,7 @@ identifiability_2_example = Example(
         ConditionalIndependency.create('Z1', 'Z5'),
         ConditionalIndependency.create('Z2', 'Z4'),
         ConditionalIndependency.create('Z2', 'Z5', ['Z4']),
-    ]
+    ],
 )
 
 #: The Identifiability 3 example

--- a/src/y0/examples.py
+++ b/src/y0/examples.py
@@ -15,6 +15,7 @@ from .struct import ConditionalIndependency, VermaConstraint
 class Example:
     """An example graph packaged with certain pre-calculated data structures."""
 
+    name: str
     graph: NxMixedGraph
     verma_constraints: Optional[Sequence[VermaConstraint]] = None
     conditional_independencies: Optional[Sequence[ConditionalIndependency]] = None
@@ -22,7 +23,6 @@ class Example:
 
 u_2 = Variable('u_2')
 
-#: The "backdoor" example
 #: Treatment: X
 #: Outcome: Y
 #: Adjusted: N/A
@@ -34,10 +34,10 @@ backdoor = NxMixedGraph.from_edges(directed=[
 ])
 
 backdoor_example = Example(
+    name='Backdoor',
     graph=backdoor,
 )
 
-#: The "frontdoor" example
 #: Treatment: X
 #: Outcome: Y
 #: Adjusted: N/A
@@ -52,10 +52,10 @@ frontdoor = NxMixedGraph.from_edges(
     ],
 )
 frontdoor_example = Example(
+    name='Frontdoor',
     graph=frontdoor,
 )
 
-#: The Instrument Variable example
 #: Treatment: X
 #: Outcome: Y
 #: Reference: J. Pearl. 2009. "Causality: Models, Reasoning and Inference. 2nd ed." Cambridge University Press, p. 153.
@@ -69,10 +69,10 @@ instrumental_variable = NxMixedGraph.from_edges(
     ],
 )
 instrumental_variable_example = Example(
+    name='Instrument Variable',
     graph=instrumental_variable,
 )
 
-#: The Napkin example
 #: Treatment: X
 #: Outcome: Y
 #: Reference: J. Pearl and D. Mackenzie. 2018. "The Book of Why: The New Science of Cause and Effect." Basic Books,
@@ -89,6 +89,7 @@ napkin = NxMixedGraph.from_edges(
     ],
 )
 napkin_example = Example(
+    name='Napkin',
     graph=napkin,
     verma_constraints=[
         VermaConstraint(
@@ -104,7 +105,6 @@ napkin_example = Example(
     ],
 )
 
-#: The M-Graph example
 #: Treatment: X
 #: Outcome: Y
 #: Reference: S. Greenland, J. Pearl, and J.M. Robins. 1999. "Causal Diagrams for Epidemiologic Research." Epidemiology
@@ -119,10 +119,10 @@ m_graph = NxMixedGraph.from_edges(
     ],
 )
 m_graph_example = Example(
+    name='M-Graph',
     graph=m_graph,
 )
 
-#: The Identifiability 1 example
 #: Treatment: X
 #: Outcome: Y
 #: Reference: J. Pearl. 2009. "Causality: Models, Reasoning and Inference. 2nd ed." Cambridge University Press, p. 80.
@@ -140,6 +140,7 @@ identifiability_1 = NxMixedGraph.from_edges(
     ],
 )
 identifiability_1_example = Example(
+    name='Identifiability 1',
     graph=identifiability_1,
     conditional_independencies=(
         ConditionalIndependency.create('X', 'Z1', ['Z2', 'Z3']),
@@ -157,7 +158,6 @@ identifiability_1_example = Example(
     ),
 )
 
-#: The Identifiability 2 example
 #: Treatment: X
 #: Outcome: Y
 #: Reference: E. Bareinboim modification of Identifiability 1.
@@ -184,6 +184,7 @@ identifiability_2 = NxMixedGraph.from_edges(
     ],
 )
 identifiability_2_example = Example(
+    name='Identifiability 2',
     graph=identifiability_2,
     verma_constraints=[
         ...

--- a/src/y0/examples.py
+++ b/src/y0/examples.py
@@ -183,6 +183,41 @@ identifiability_2 = NxMixedGraph.from_edges(
         ('Z4', 'Y'),
     ],
 )
+identifiability_2_example = Example(
+    graph=identifiability_2,
+    verma_constraints=[
+        ...
+    ],
+    conditional_independencies=[
+        ConditionalIndependency.create('W0', 'W1', ['X']),
+        ConditionalIndependency.create('W0', 'W2', ['X']),
+        ConditionalIndependency.create('W0', 'Z1', ['X']),
+        ConditionalIndependency.create('W0', 'Z2', ['X']),
+        ConditionalIndependency.create('W0', 'Z3', ['X']),
+        ConditionalIndependency.create('W0', 'Z4', ['X']),
+        ConditionalIndependency.create('W0', 'Z5', ['X']),
+        ConditionalIndependency.create('W1', 'Y', ['W0', 'W2', 'Z3', 'Z4', 'Z5']),
+        ConditionalIndependency.create('W1', 'Z1', ['X']),
+        ConditionalIndependency.create('W1', 'Z2', ['X']),
+        ConditionalIndependency.create('W1', 'Z3', ['X']),
+        ConditionalIndependency.create('W1', 'Z4', ['X']),
+        ConditionalIndependency.create('W1', 'Z5', ['X']),
+        ConditionalIndependency.create('W2', 'X', ['W1']),
+        ConditionalIndependency.create('W2', 'Z1', ['W1']),
+        ConditionalIndependency.create('W2', 'Z2', ['W1']),
+        ConditionalIndependency.create('W2', 'Z3', ['W1']),
+        ConditionalIndependency.create('W2', 'Z4', ['W1']),
+        ConditionalIndependency.create('X', 'Y', ['W0', 'W2', 'Z2', 'Z4', 'Z5']),
+        ConditionalIndependency.create('X', 'Z4', ['Z1', 'Z2', 'Z3']),
+        ConditionalIndependency.create('X', 'Z5', ['Z1', 'Z2', 'Z3']),
+        ConditionalIndependency.create('Y', 'Z1', ['W0', 'W2', 'Z3', 'Z4', 'Z6']),
+        ConditionalIndependency.create('Y', 'Z2', ['W0', 'W2', 'Z3', 'Z4', 'Z6']),
+        ConditionalIndependency.create('Z1', 'Z4'),
+        ConditionalIndependency.create('Z1', 'Z5'),
+        ConditionalIndependency.create('Z2', 'Z4'),
+        ConditionalIndependency.create('Z2', 'Z5', ['Z4']),
+    ]
+)
 
 #: The Identifiability 3 example
 #: Treatment: X
@@ -449,3 +484,5 @@ identifiability_linear_1 = NxMixedGraph.from_edges(
         ('W', 'Y'),
     ],
 )
+
+examples = [v for name, v in locals().items() if name.endswith('_example')]

--- a/src/y0/struct.py
+++ b/src/y0/struct.py
@@ -11,6 +11,7 @@ from .dsl import Expression, Variable, _upgrade_ordering
 
 __all__ = [
     'VermaConstraint',
+    'ConditionalIndependency',
 ]
 
 

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -4,6 +4,8 @@
 
 import unittest
 
+import pyparsing
+
 from y0.dsl import P, Q, Sum, Variable
 from y0.examples import examples, verma_1
 
@@ -43,7 +45,10 @@ class TestCausalEffect(unittest.TestCase):
         """Test getting the single Verma constraint from the Figure 1A graph."""
         for example in examples:
             with self.subTest(name=example.name):
-                actual = r_get_verma_constraints(example.graph)
+                try:
+                    actual = r_get_verma_constraints(example.graph)
+                except pyparsing.ParseException:
+                    continue
                 expected = example.verma_constraints
                 self.assertEqual(set(expected or ()), set(actual))
 

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -5,7 +5,7 @@
 import unittest
 
 from y0.dsl import P, Q, Sum, Variable
-from y0.examples import verma_1
+from y0.examples import examples, verma_1
 
 try:
     from y0.causaleffect import r_get_verma_constraints
@@ -41,6 +41,12 @@ class TestCausalEffect(unittest.TestCase):
 
     def test_verma_constraint(self):
         """Test getting the single Verma constraint from the Figure 1A graph."""
+        for example in examples:
+            with self.subTest():
+                actual = r_get_verma_constraints(example.graph)
+                expected = example.verma_constraints
+                self.assertEqual(set(expected or ()), set(actual))
+
         actual = r_get_verma_constraints(verma_1)
         self.assertEqual(1, len(actual))
         verma_constraint = actual[0]

--- a/tests/test_causaleffect.py
+++ b/tests/test_causaleffect.py
@@ -42,7 +42,7 @@ class TestCausalEffect(unittest.TestCase):
     def test_verma_constraint(self):
         """Test getting the single Verma constraint from the Figure 1A graph."""
         for example in examples:
-            with self.subTest():
+            with self.subTest(name=example.name):
                 actual = r_get_verma_constraints(example.graph)
                 expected = example.verma_constraints
                 self.assertEqual(set(expected or ()), set(actual))


### PR DESCRIPTION
This PR adds more examples of Verma constraints and introduces a data structure for storing conditional independences. This will make testing of #24 and #25 much easier.


There are a few issues with parsing the Verma constraints for the napkin graph and identifiability 2, but I didn't want to hold up this PR for updating the parser (it's also possible some examples just can't be parsed)