### PR TITLE
Add y0 DSL output and generalize P()

### DIFF
--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -398,7 +398,7 @@ class Distribution(Element):
                 i = dist_pos[0]
                 pre = cast(Iterable[Union[str, Variable]], extended_args[:i])
                 dist = cast(Distribution, extended_args[i])
-                post = cast(Iterable[Union[str, Variable]], extended_args[i + 1:])
+                post = cast(Iterable[Union[str, Variable]], extended_args[i + 1 :])
                 return Distribution(
                     children=(*_upgrade_ordering(pre), *dist.children),
                     parents=(*dist.parents, *_upgrade_ordering(post)),

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -842,7 +842,7 @@ class Sum(Expression):
             s = self.expression.to_y0()
         if not self.ranges:
             return f"Sum({s})"
-        ranges = _list_to_text(self.ranges)
+        ranges = _list_to_y0(self.ranges)
         return f"Sum[{ranges}]({s})"
 
     def __mul__(self, expression: Expression):

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -400,8 +400,8 @@ class Distribution(Element):
                 dist = cast(Distribution, extended_args[i])
                 post = cast(Iterable[Union[str, Variable]], extended_args[i + 1 :])
                 return Distribution(
-                    children=(*_upgrade_ordering(pre), *dist.children),
-                    parents=(*dist.parents, *_upgrade_ordering(post)),
+                    children=_sorted_variables((*_upgrade_ordering(pre), *dist.children)),
+                    parents=_sorted_variables((*dist.parents, *_upgrade_ordering(post))),
                 )
 
             # Multiple conditionals were detected. This isn't allowed.
@@ -414,27 +414,23 @@ class Distribution(Element):
                 children=_upgrade_ordering(distribution),
             )
 
-    def _to_x(self, f: Callable[[Iterable[Variable]], str], parens: bool) -> str:
-        children = f(self.children)
+    def _to_x(self, func: Callable[[Iterable[Variable]], str]) -> str:
+        children = func(self.children)
         if not self.parents:
             return children
-        parents = f(self.parents)
-        if parens and 1 < len(self.parents):
-            return f"{children}|({parents})"
-        else:
-            return f"{children}|{parents}"
+        return f"{children}|{func(self.parents)}"
 
     def to_text(self) -> str:
         """Output this distribution in the internal string format."""
-        return self._to_x(_list_to_text, parens=False)
+        return self._to_x(_list_to_text)
 
     def to_y0(self) -> str:
         """Output this distribution instance as y0 internal DSL code."""
-        return self._to_x(_list_to_y0, parens=True)
+        return self._to_x(_list_to_y0)
 
     def to_latex(self) -> str:
         """Output this distribution in the LaTeX string format."""
-        return self._to_x(_list_to_latex, parens=False)
+        return self._to_x(_list_to_latex)
 
     def is_conditioned(self) -> bool:
         """Return if this distribution is conditioned."""

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -17,7 +17,7 @@ from pyparsing import (
 )
 
 from .utils import probability_pe, qfactor_pe, variables_pe
-from ...dsl import Expression, Fraction, Product, Sum
+from ...dsl import Expression, Fraction, Product, Sum, _sorted_variables
 
 __all__ = [
     "parse_causaleffect",
@@ -30,7 +30,7 @@ expr = Forward()
 
 def _make_sum(_s, _l, tokens: ParseResults) -> Sum:
     return Sum(
-        ranges=tuple(tokens["ranges"].asList()) if "ranges" in tokens else tuple(),
+        ranges=_sorted_variables(tokens["ranges"].asList() if "ranges" in tokens else []),
         expression=tokens["expression"],
     )
 

--- a/src/y0/parser/craig/utils.py
+++ b/src/y0/parser/craig/utils.py
@@ -19,6 +19,7 @@ from ...dsl import (
     Probability,
     QFactor,
     Variable,
+    _sorted_variables,
 )
 
 __all__ = [
@@ -60,12 +61,19 @@ def _make_probability(_s, _l, tokens: ParseResults) -> Probability:
     children, parents = tokens["children"].asList(), tokens["parents"].asList()
     if not children:
         raise ValueError
-    return Probability(Distribution(children=tuple(children), parents=tuple(parents)))
+    return Probability(
+        Distribution(
+            children=_sorted_variables(children),
+            parents=_sorted_variables(parents),
+        )
+    )
 
 
 def _make_q(_s, _l, tokens: ParseResults) -> QFactor:
-    codomain, domain = tokens["codomain"].asList(), tokens["domain"].asList()
-    return QFactor(codomain=tuple(codomain), domain=tuple(domain))
+    return QFactor(
+        codomain=_sorted_variables(tokens["codomain"].asList()),
+        domain=_sorted_variables(tokens["domain"].asList()),
+    )
 
 
 # The suffix "pe" refers to :class:`pyparsing.ParserElement`, which is the

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -29,6 +29,7 @@ from y0.dsl import (
     Y,
     Z,
 )
+from y0.parser import parse_y0
 
 V = Variable("V")
 
@@ -43,8 +44,14 @@ class TestDSL(unittest.TestCase):
         self.assertIsInstance(expression.to_text(), str)
         self.assertIsInstance(expression.to_latex(), str)
         self.assertIsInstance(expression._repr_latex_(), str)
-        # self.assertEqual(expression, parse_y0(expression.to_y0()))
         self.assertEqual(s, expression.to_text(), msg=f"Expression: {repr(expression)}")
+        if not isinstance(expression, Distribution):
+            reconstituted = parse_y0(expression.to_y0())
+            self.assertEqual(
+                expression,
+                reconstituted,
+                msg=f'\nExpected: {expression.to_y0()}\nActual:   {reconstituted.to_y0()}',
+            )
 
     def test_variable(self):
         """Test the variable DSL object."""

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -286,7 +286,7 @@ class TestDSL(unittest.TestCase):
             " [ sum_{} [ sum_{D,W,X,Y,Z} P(D,V,W,X,Y,Z) ] ] ]",
             Sum[W, D, Z, V](
                 Sum(P(W | X))
-                * Sum(Sum[X, W, Z, Y, V](P(D, V, W, X, Y, Z, )))
+                * Sum(Sum[X, W, Z, Y, V](P(D, V, W, X, Y, Z)))
                 * Sum(P(Z | D, V))
                 * Sum(Sum[X](P(Y | D, V, W, X, Z) * P(X)))
                 * Sum(Sum[X, W, D, Z, Y](P(X, W, D, Z, Y, V))),

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -45,12 +45,12 @@ class TestDSL(unittest.TestCase):
         self.assertIsInstance(expression.to_latex(), str)
         self.assertIsInstance(expression._repr_latex_(), str)
         self.assertEqual(s, expression.to_text(), msg=f"Expression: {repr(expression)}")
-        if not isinstance(expression, Distribution):
+        if not isinstance(expression, (Distribution, Intervention)):
             reconstituted = parse_y0(expression.to_y0())
             self.assertEqual(
                 expression,
                 reconstituted,
-                msg=f'\nExpected: {expression.to_y0()}\nActual:   {reconstituted.to_y0()}',
+                msg=f"\nExpected: {expression.to_y0()}\nActual:   {reconstituted.to_y0()}",
             )
 
     def test_variable(self):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -12,6 +12,7 @@ from y0.dsl import (
     CounterfactualVariable,
     D,
     Distribution,
+    Element,
     Fraction,
     Intervention,
     One,
@@ -28,7 +29,6 @@ from y0.dsl import (
     Y,
     Z,
 )
-from y0.parser import parse_y0
 
 V = Variable("V")
 
@@ -36,14 +36,14 @@ V = Variable("V")
 class TestDSL(unittest.TestCase):
     """Tests for the stringifying instances of the probability DSL."""
 
-    def assert_text(self, s: str, expression):
+    def assert_text(self, s: str, expression: Element):
         """Assert the expression when it is converted to a string."""
         self.assertIsInstance(s, str)
         self.assertIsInstance(hash(expression), int)  # can the expression be hashed?
         self.assertIsInstance(expression.to_text(), str)
         self.assertIsInstance(expression.to_latex(), str)
         self.assertIsInstance(expression._repr_latex_(), str)
-        self.assertEqual(expression, parse_y0(expression.to_y0()))
+        # self.assertEqual(expression, parse_y0(expression.to_y0()))
         self.assertEqual(s, expression.to_text(), msg=f"Expression: {repr(expression)}")
 
     def test_variable(self):
@@ -55,6 +55,8 @@ class TestDSL(unittest.TestCase):
         """Test that a variable can not be named "P"."""
         with self.assertRaises(ValueError):
             _ = Variable("P")
+        with self.assertRaises(ValueError):
+            _ = Variable("Q")
 
     def test_intervention(self):
         """Test the invervention DSL object."""
@@ -235,10 +237,10 @@ class TestDSL(unittest.TestCase):
 
     def test_q(self):
         """Test the Q DSL object."""
-        self.assert_text("Q[A](X)", Q[A](X))
-        self.assert_text("Q[A,B](X)", Q[A, B](X))
-        self.assert_text("Q[A](X,Y)", Q[A](X, Y))
-        self.assert_text("Q[A,B](X,Y)", Q[A, B](X, Y))
+        self.assert_text("Q[A](X)", Q[A](X))  # type: ignore
+        self.assert_text("Q[A,B](X)", Q[A, B](X))  # type: ignore
+        self.assert_text("Q[A](X,Y)", Q[A](X, Y))  # type: ignore
+        self.assert_text("Q[A,B](X,Y)", Q[A, B](X, Y))  # type: ignore
 
     def test_jeremy(self):
         """Test assorted complicated objects from Jeremy."""
@@ -297,7 +299,7 @@ class TestDSL(unittest.TestCase):
             (One() / P(A @ B), {A @ B, -B}),
             (P(B) / P(A @ ~B), {A @ ~B, B, ~B}),
             (P(Y | X) * P(X) / P(Y), {X, Y}),
-            (Q[A, B](C, D), {A, B, C, D}),
+            (Q[A, B](C, D), {A, B, C, D}),  # type: ignore
         ]:
             with self.subTest(expression=str(expression)):
                 self.assertEqual(variables, expression.get_variables())

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -258,37 +258,37 @@ class TestDSL(unittest.TestCase):
     def test_jeremy(self):
         """Test assorted complicated objects from Jeremy."""
         self.assert_text(
-            "[ sum_{W} P(Y_{Z*,W},X) P(D) P(Z_{D}) P(W_{X*}) ]",
-            Sum(P((Y @ ~Z @ W) & X) * P(D) * P(Z @ D) * P(W @ ~X), (W,)),
+            "[ sum_{W} P(X,Y_{Z*,W}) P(D) P(Z_{D}) P(W_{X*}) ]",
+            Sum(P(X, (Y @ ~Z @ W)) * P(D) * P(Z @ D) * P(W @ ~X), (W,)),
         )
 
         self.assert_text(
-            "[ sum_{W} P(Y_{Z*,W},X) P(W_{X*}) ]",
-            Sum(P(Y @ ~Z @ W & X) * P(W @ ~X), (W,)),
+            "[ sum_{W} P(X,Y_{Z*,W}) P(W_{X*}) ]",
+            Sum(P(X, Y @ ~Z @ W) * P(W @ ~X), (W,)),
         )
 
         self.assert_text(
-            "frac_{[ sum_{W} P(Y_{Z,W},X) P(W_{X*}) ]}{[ sum_{Y} [ sum_{W} P(Y_{Z,W},X) P(W_{X*}) ] ]}",
+            "frac_{[ sum_{W} P(X,Y_{Z,W}) P(W_{X*}) ]}{[ sum_{Y} [ sum_{W} P(X,Y_{Z,W}) P(W_{X*}) ] ]}",
             Fraction(
-                Sum(P(Y @ Z @ W & X) * P(W @ ~X), (W,)),
-                Sum(Sum(P(Y @ Z @ W & X) * P(W @ ~X), (W,)), (Y,)),
+                Sum(P(X, Y @ Z @ W) * P(W @ ~X), (W,)),
+                Sum(Sum(P(X, Y @ Z @ W) * P(W @ ~X), (W,)), (Y,)),
             ),
         )
 
         self.assert_text(
-            "[ sum_{D} P(Y_{Z*,W},X) P(D) P(Z_{D}) P(W_{X*}) ]",
-            Sum(P(Y @ ~Z @ W & X) * P(D) * P(Z @ D) * P(W @ ~X), (D,)),
+            "[ sum_{D} P(X,Y_{Z*,W}) P(D) P(Z_{D}) P(W_{X*}) ]",
+            Sum(P(X, Y @ ~Z @ W) * P(D) * P(Z @ D) * P(W @ ~X), (D,)),
         )
 
         self.assert_text(
-            "[ sum_{W,D,Z,V} [ sum_{} P(W|X) ] [ sum_{} [ sum_{X,W,Z,Y,V} P(X,W,D,Z,Y,V) ] ]"
-            " [ sum_{} P(Z|D,V) ] [ sum_{} [ sum_{X} P(Y|X,D,V,Z,W) P(X) ] ]"
-            " [ sum_{} [ sum_{X,W,D,Z,Y} P(X,W,D,Z,Y,V) ] ] ]",
+            "[ sum_{D,V,W,Z} [ sum_{} P(W|X) ] [ sum_{} [ sum_{V,W,X,Y,Z} P(D,V,W,X,Y,Z) ] ]"
+            " [ sum_{} P(Z|D,V) ] [ sum_{} [ sum_{X} P(Y|D,V,W,X,Z) P(X) ] ]"
+            " [ sum_{} [ sum_{D,W,X,Y,Z} P(D,V,W,X,Y,Z) ] ] ]",
             Sum[W, D, Z, V](
                 Sum(P(W | X))
-                * Sum(Sum[X, W, Z, Y, V](P(X, W, D, Z, Y, V)))
-                * Sum(P(Z | [D, V]))
-                * Sum(Sum[X](P(Y | [X, D, V, Z, W]) * P(X)))
+                * Sum(Sum[X, W, Z, Y, V](P(D, V, W, X, Y, Z, )))
+                * Sum(P(Z | D, V))
+                * Sum(Sum[X](P(Y | D, V, W, X, Z) * P(X)))
                 * Sum(Sum[X, W, D, Z, Y](P(X, W, D, Z, Y, V))),
             ),
         )

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -157,9 +157,13 @@ class TestDSL(unittest.TestCase):
         self.assert_text("P(A)", P("A"))
         self.assert_text("P(A)", P(Distribution((A,))))
 
-        # Test markov kernels (AKA has only one child variable)
+        # Test markov kernel with single parent (AKA has only one child variable)
+        self.assert_text("P(A|B)", P(A | B))
         self.assert_text("P(A|B)", P(Distribution((A,), (B,))))
         self.assert_text("P(A|B)", P(A | [B]))
+
+        # Test markov kernel with multiple parents
+        self.assert_text("P(A|B,C)", P(A | B, C))
         self.assert_text("P(A|B,C)", P(Distribution((A,), (B,)) | C))
         self.assert_text("P(A|B,C)", P(A | [B, C]))
         self.assert_text("P(A|B,C)", P(A | B | C))
@@ -182,12 +186,14 @@ class TestDSL(unittest.TestCase):
         self.assert_text("P(A,B,C)", P(Variable(name) for name in "ABC"))
 
         # Test mixed with single conditional
+        self.assert_text("P(A,B|C)", P(A, B | C))
         self.assert_text("P(A,B|C)", P(Distribution((A, B), (C,))))
         self.assert_text("P(A,B|C)", P(Distribution((A, B), (C,))))
         self.assert_text("P(A,B|C)", P(Distribution((A, B)) | C))
         self.assert_text("P(A,B|C)", P(A & B | C))
 
         # Test mixed with multiple conditionals
+        self.assert_text("P(A,B|C,D)", P(A, B | C, D))
         self.assert_text("P(A,B|C,D)", P(Distribution((A, B), (C, D))))
         self.assert_text("P(A,B|C,D)", P(Distribution((A, B)) | C | D))
         self.assert_text("P(A,B|C,D)", P(Distribution((A, B), (C,)) | D))

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -28,6 +28,7 @@ from y0.dsl import (
     Y,
     Z,
 )
+from y0.parser import parse_y0
 
 V = Variable("V")
 
@@ -42,6 +43,7 @@ class TestDSL(unittest.TestCase):
         self.assertIsInstance(expression.to_text(), str)
         self.assertIsInstance(expression.to_latex(), str)
         self.assertIsInstance(expression._repr_latex_(), str)
+        self.assertEqual(expression, parse_y0(expression.to_y0()))
         self.assertEqual(s, expression.to_text(), msg=f"Expression: {repr(expression)}")
 
     def test_variable(self):

--- a/tests/test_mutate/test_canonicalize.py
+++ b/tests/test_mutate/test_canonicalize.py
@@ -167,5 +167,4 @@ class TestCanonicalizeEqual(unittest.TestCase):
         self.assertFalse(canonical_expr_equal(P(X @ W), P(Y)))
 
         # Order changes
-        self.assertNotEqual(P(X, Y), P(Y, X))
-        self.assertTrue(canonical_expr_equal(P(X, Y), P(Y, X)))
+        self.assertTrue(canonical_expr_equal(P(X & Y), P(Y & X)))

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ deps =
     types-click
     types-tabulate
 skip_install = true
-commands = mypy --ignore-missing-imports src/y0/
+commands = mypy --ignore-missing-imports src/y0/ tests/test_dsl.py
 description = Run the mypy tool to check static typing on the project.
 
 [testenv:doc8]


### PR DESCRIPTION
This PR does the following:

1. Adds the `to_y0()` function to all DSL elements. The result is code that would be possible to copy/paste into the Python REPL after importing the default `from y0.dsl import *`. Python itself can be a parser for these strings, but you can also use `y0.parser.parse_y0` to operate on these strings
2. Add a bit of auto-sorting when using high level functions like `P()`, `Q()`, and all `.safe()` functions.
3. Generalize the `P()` function so you can write stuff like this:

```python
from y0.dsl import *

P(A | B)

P(A | B, C)

P(A, B | C, D)
```

There's _even more_ magic logic to make this work now :)