### PR TITLE
Fix bug in `NxMixedGraph.intervene()`

### DIFF
--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -319,7 +319,7 @@ class NxMixedGraph(Generic[NodeType]):
             if intervention in nodes:
                 continue
             elif not isinstance(intervention, Intervention):
-                raise KeyError(f"{type(intervention)} {intervention} not in nodes")
+                raise TypeError(f"{intervention} is not an intervention")
             not_node = Variable(str(~intervention))
             node = Variable(str(intervention))
             if node in nodes:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -9,7 +9,7 @@ from typing import Set, Tuple
 import networkx as nx
 from ananke.graphs import ADMG
 
-from y0.dsl import X, Y, Z
+from y0.dsl import X, Y, Z, W
 from y0.examples import verma_1
 from y0.graph import DEFAULT_TAG, DEFULT_PREFIX, NxMixedGraph
 from y0.resources import VIRAL_PATHOGENESIS_PATH
@@ -147,6 +147,10 @@ class TestGraph(unittest.TestCase):
         .. seealso:: https://github.com/y0-causal-inference/y0/issues/83
         """
         backdoor = NxMixedGraph.from_edges(directed=[(Z, Y), (Z, X), (X, Y)])
+        with self.assertRaises(TypeError):
+            backdoor.intervene({5})
+        with self.assertRaises(KeyError):
+            backdoor.intervene({-W})
         backdoor_intervention1 = NxMixedGraph.from_edges(directed=[(Z, Y), (X, Y)])
         self.assertEqual(backdoor_intervention1, backdoor.intervene({X}))
         backdoor_intervention2 = NxMixedGraph.from_edges(directed=[(Z, Y), (~X, Y)])


### PR DESCRIPTION
Closes #83

This PR excises the unit test and solution from #76 originally written by @djinnome because that PR is now too complicated to review _any_ of its code in its current state. We can finalize this fix here, then merge back into #76 after.