### PR TITLE
Add predicates for finding good and bad controls

### DIFF
--- a/src/y0/predicates.py
+++ b/src/y0/predicates.py
@@ -2,10 +2,13 @@
 
 """Predicates for expressions."""
 
-from .dsl import Expression, Fraction, Probability, Product, Sum
+from .dsl import Expression, Fraction, Probability, Product, Sum, Variable
+from .graph import NxMixedGraph
 
 __all__ = [
     "has_markov_postcondition",
+    "is_good_control",
+    "is_bad_control",
 ]
 
 
@@ -28,3 +31,26 @@ def has_markov_postcondition(expression: Expression) -> bool:
         )
     else:
         raise TypeError
+
+
+def _control_precondition(graph: NxMixedGraph, query: Probability, variable: Variable):
+    if missing := query.get_variables().difference(graph.nodes()):
+        raise ValueError(f"Query variables missing: {missing}")
+    if variable not in graph.nodes():
+        raise ValueError(f"Test variable missing: {variable}")
+    # TODO does this need to be extended to check that the
+    #  query and variable aren't counterfactual?
+
+
+def is_good_control(graph: NxMixedGraph, query: Probability, variable: Variable) -> bool:
+    """Return if the variable is a good control."""
+    _control_precondition(graph, query, variable)
+
+    raise NotImplementedError
+
+
+def is_bad_control(graph: NxMixedGraph, query: Probability, variable: Variable) -> bool:
+    """Return if the variable is a good control."""
+    _control_precondition(graph, query, variable)
+
+    raise NotImplementedError

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for good, bad, and neutral controls."""
+
+import unittest
+
+from y0.dsl import M, P, U1, U2, Variable, X, Y, Z
+from y0.graph import NxMixedGraph
+from y0.predicates import is_bad_control, is_good_control
+
+U = Variable("U")
+query = P(Y @ X)
+
+model_1 = NxMixedGraph.from_edges(directed=[(Z, X), (Z, Y), (X, Y)])
+model_2 = NxMixedGraph.from_edges(directed=[(U, Z), (Z, X), (X, Y), (U, Y)])
+model_3 = NxMixedGraph.from_edges(directed=[(U, X), (U, Z), (Z, Y), (X, Y)])
+model_4 = NxMixedGraph.from_edges(directed=[(Z, X), (Z, M), (X, M), (M, Y)])
+model_5 = NxMixedGraph.from_edges(directed=[(U, Z), (Z, X), (U, M), (X, M), (M, Y)])
+model_6 = NxMixedGraph.from_edges(directed=[(U, X), (U, Z), (Z, M), (X, M), (M, Y)])
+
+good_test_models = [
+    model_1,
+    model_2,
+    model_3,
+    model_4,
+    model_5,
+    model_6,
+]
+
+# M-bias
+model_7 = NxMixedGraph.from_edges(directed=[(U1, Z), (U2, Z), (U1, X), (U2, Y), (X, Y)])
+# Bias amplification
+model_10 = NxMixedGraph.from_edges(directed=[(Z, X), (U, X), (U, Y), (X, Y)])
+#
+model_11 = NxMixedGraph.from_edges(directed=[(X, Z), (Z, Y)])
+model_11_variation = NxMixedGraph.from_edges(directed=[(X, Z), (U, Z), (Z, Y), (U, Y)])
+model_12 = NxMixedGraph.from_edges(directed=[(X, M), (M, Y), (M, Z)])
+# Selection bias
+model_16 = NxMixedGraph.from_edges(directed=[(X, Z), (U, Z), (U, Y), (X, Y)])
+model_17 = NxMixedGraph.from_edges(directed=[(X, Z), (Y, Z), (X, Y)])
+# case-control bias
+model_18 = NxMixedGraph.from_edges(directed=[(X, Y), (Y, Z)])
+
+bad_test_models = [
+    model_7,
+    model_10,
+    model_11,
+    model_11_variation,
+    model_12,
+    model_16,
+    model_17,
+    model_18,
+]
+
+
+class TestControls(unittest.TestCase):
+    """Test case for good, bad, and neutral controls."""
+
+    def test_good_controls(self):
+        """Test good controls."""
+        for model in good_test_models:
+            with self.subTest():
+                self.assertTrue(is_good_control(model, query, Z))
+        for model in bad_test_models:
+            with self.subTest():
+                self.assertFalse(is_good_control(model, query, Z))
+
+        # TODO need alternative negative examples
+
+    def test_bad_controls(self):
+        """Test bad controls."""
+        for model in good_test_models:
+            with self.subTest():
+                self.assertFalse(is_bad_control(model, query, Z))
+        for model in bad_test_models:
+            with self.subTest():
+                self.assertTrue(is_bad_control(model, query, Z))
+
+        # TODO need alternative negative examples


### PR DESCRIPTION
This PR adds predicates for testing if a given variable is a good or bad control based on <add reference>. This PR doesn't implement checks for neutral controls, as those don't have a ton of rules yet.

- [x] Pick interface for predicate functions and implement stubs (@cthoyt)
- [x] Add unit tests based on @srtaheri's slides (@cthoyt)
- [ ] Implement `is_good_control` predicate (@cthoyt  + @vartikatewari)
- [ ] Implement `is_bad_control` predicate (@cthoyt  + @vartikatewari)