### PR TITLE
Add definition of "expression complexity"

### DIFF
--- a/src/y0/algorithm/taheri_design.py
+++ b/src/y0/algorithm/taheri_design.py
@@ -18,6 +18,7 @@ from more_click import verbose_option
 from tabulate import tabulate
 from tqdm import tqdm
 
+from y0.complexity import complexity
 from y0.algorithm.identify import Identification, Unidentifiable, identify
 from y0.algorithm.simplify_latent import simplify_latent_dag
 from y0.dsl import Expression, P, Variable
@@ -284,9 +285,10 @@ def draw_results(
             ax.axis("off")
         else:
             mixed_graph = NxMixedGraph.from_admg(result.admg)  # type:ignore
+            estimand_complexity = complexity(result.estimand)
             title = f"{i}) Latent: " + ", ".join(result.latents)
             if result.estimand is not None:
-                title += f"\n${result.estimand.to_latex()}$"
+                title += f"\n${result.estimand.to_latex()}$\n$C={estimand_complexity}$"
             mixed_graph.draw(ax=ax, title="\n".join(textwrap.wrap(title, width=45)))
 
     fig.tight_layout()

--- a/src/y0/algorithm/taheri_design.py
+++ b/src/y0/algorithm/taheri_design.py
@@ -17,9 +17,9 @@ from more_click import verbose_option
 from tabulate import tabulate
 from tqdm import tqdm
 
-from y0.complexity import complexity
 from y0.algorithm.identify import Identification, Unidentifiable, identify
 from y0.algorithm.simplify_latent import simplify_latent_dag
+from y0.complexity import complexity
 from y0.dsl import Expression, P, Variable
 from y0.graph import DEFAULT_TAG, NxMixedGraph
 from y0.identify import is_identifiable

--- a/src/y0/complexity.py
+++ b/src/y0/complexity.py
@@ -5,8 +5,10 @@
 from typing import Sequence
 
 from .dsl import (
+    CounterfactualVariable,
     Expression,
     Fraction,
+    Intervention,
     One,
     Probability,
     Product,
@@ -26,10 +28,15 @@ FRAC_CONST = 0.0
 PROD_CONST = 0.0
 PROB_CONST = 0.0
 Q_CONST = 0.0
+VAR_CONSTANT = 1.0  # yo cat
 
 
 def complexity(expr: Expression) -> float:
-    """Calculate the complexity of the given expression, recursively."""
+    """Calculate the "complexity" of the expression, where a bigger result means more complex.
+
+
+    :param expr: The input expression (can be any DSL element except
+    """
     if isinstance(expr, (One, Zero)):
         return CONST_CONST
     if isinstance(expr, Fraction):
@@ -41,19 +48,25 @@ def complexity(expr: Expression) -> float:
     if isinstance(expr, QFactor):
         return Q_CONST + range_complexity(expr.domain) + range_complexity(expr.codomain)
     if isinstance(expr, Probability):
-        return PROB_CONST + prob_complexity(expr)
+        return PROB_CONST + probability_complexity(expr)
     raise TypeError(f"Unhandled expression type: {expr.__class__.__name__}")
 
 
 def range_complexity(variables: Sequence[Variable]) -> float:
     """Return the complexity of a sequence of variables."""
-    return sum(var_complexity(v) for v in variables)
+    return sum(variable_complexity(v) for v in variables)
 
 
-def var_complexity(variable: Variable) -> float:
+def variable_complexity(variable: Variable) -> float:
     """Return the complexity of a single variable."""
-    return 1.0  # FIXME
+    if isinstance(variable, CounterfactualVariable):
+        return VAR_CONSTANT + sum(variable_complexity(v) for v in variable.interventions)
+    elif isinstance(variable, Intervention):
+        return VAR_CONSTANT
+    else:
+        return VAR_CONSTANT
 
 
-def prob_complexity(expr: Probability) -> float:
-    raise NotImplementedError
+def probability_complexity(expr: Probability) -> float:
+    """Return the complexity of a probability expression."""
+    return range_complexity(expr.children) + range_complexity(expr.parents)

--- a/src/y0/complexity.py
+++ b/src/y0/complexity.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+"""Calculate the complexity of an expression."""
+
+from typing import Sequence
+
+from .dsl import Expression, Fraction, One, Probability, Product, QFactor, Sum, Variable, Zero
+
+__all__ = [
+    "complexity"
+]
+
+CONST_CONST = 1.0  # yo dawg
+SUM_CONST = 0.0
+FRAC_CONST = 0.0
+PROD_CONST = 0.0
+PROB_CONST = 0.0
+Q_CONST = 0.0
+
+
+def complexity(expr: Expression) -> float:
+    """Calculate the complexity of the given expression, recursively."""
+    if isinstance(expr, (One, Zero)):
+        return CONST_CONST
+
+    if isinstance(expr, Fraction):
+        return FRAC_CONST + complexity(expr.numerator) + complexity(expr.denominator)
+
+    if isinstance(expr, Product):
+        return PROD_CONST + sum(
+            complexity(subexpr)
+            for subexpr in expr.expressions
+        )
+
+    if isinstance(expr, Sum):
+        return SUM_CONST + range_complexity(expr.ranges) + complexity(expr.expression)
+
+    if isinstance(expr, QFactor):
+        return range_complexity(expr.domain) + range_complexity(expr.codomain)
+
+    if isinstance(expr, Probability):
+        return PROB_CONST + prob_complexity(expr)
+
+    raise TypeError(f"Unhandled expression type: {expr.__class__.__name__}")
+
+
+def range_complexity(variables: Sequence[Variable]) -> float:
+    """Return the complexity of a sequence of variables."""
+    return sum(var_complexity(v) for v in variables)
+
+
+def var_complexity(variable: Variable) -> float:
+    """Return the complexity of a single variable."""
+    return 1.0  # FIXME
+
+
+def prob_complexity(expr: Probability) -> float:
+    raise NotImplementedError

--- a/src/y0/complexity.py
+++ b/src/y0/complexity.py
@@ -23,19 +23,22 @@ __all__ = [
 ]
 
 CONST_CONST = 1.0  # yo dawg
+VAR_CONSTANT = 1.0  # yo cat
 SUM_CONST = 0.0
 FRAC_CONST = 0.0
 PROD_CONST = 0.0
 PROB_CONST = 0.0
 Q_CONST = 0.0
-VAR_CONSTANT = 1.0  # yo cat
 
 
 def complexity(expr: Expression) -> float:
     """Calculate the "complexity" of the expression, where a bigger result means more complex.
 
+    Currently, the complexity of the expression is defined recursively, where all of the
+    parts of each expression are added up, counting the number of variables in each.
 
-    :param expr: The input expression (can be any DSL element except
+    :param expr: The input expression
+    :return: The complexity of the expression
     """
     if isinstance(expr, (One, Zero)):
         return CONST_CONST

--- a/src/y0/complexity.py
+++ b/src/y0/complexity.py
@@ -4,10 +4,20 @@
 
 from typing import Sequence
 
-from .dsl import Expression, Fraction, One, Probability, Product, QFactor, Sum, Variable, Zero
+from .dsl import (
+    Expression,
+    Fraction,
+    One,
+    Probability,
+    Product,
+    QFactor,
+    Sum,
+    Variable,
+    Zero,
+)
 
 __all__ = [
-    "complexity"
+    "complexity",
 ]
 
 CONST_CONST = 1.0  # yo dawg
@@ -22,25 +32,16 @@ def complexity(expr: Expression) -> float:
     """Calculate the complexity of the given expression, recursively."""
     if isinstance(expr, (One, Zero)):
         return CONST_CONST
-
     if isinstance(expr, Fraction):
         return FRAC_CONST + complexity(expr.numerator) + complexity(expr.denominator)
-
     if isinstance(expr, Product):
-        return PROD_CONST + sum(
-            complexity(subexpr)
-            for subexpr in expr.expressions
-        )
-
+        return PROD_CONST + sum(complexity(subexpr) for subexpr in expr.expressions)
     if isinstance(expr, Sum):
         return SUM_CONST + range_complexity(expr.ranges) + complexity(expr.expression)
-
     if isinstance(expr, QFactor):
-        return range_complexity(expr.domain) + range_complexity(expr.codomain)
-
+        return Q_CONST + range_complexity(expr.domain) + range_complexity(expr.codomain)
     if isinstance(expr, Probability):
         return PROB_CONST + prob_complexity(expr)
-
     raise TypeError(f"Unhandled expression type: {expr.__class__.__name__}")
 
 

--- a/src/y0/complexity.py
+++ b/src/y0/complexity.py
@@ -39,6 +39,8 @@ def complexity(expr: Expression) -> float:
 
     :param expr: The input expression
     :return: The complexity of the expression
+    :raises TypeError:
+        Raised if an invalid expression type is used
     """
     if isinstance(expr, (One, Zero)):
         return CONST_CONST

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for expression complexity.
+
+Note: tests in this module should **NOT** use exact
+numbers, but should rather encode our intuitive ideas
+of what's more complex by comparing expressions.
+"""
+
+import unittest
+
+from y0.complexity import complexity
+from y0.dsl import A, B, C, D, X, Y, Z, Expression, P
+from y0.mutate import fraction_expand, bayes_expand, chain_expand
+
+
+class TestComplexity(unittest.TestCase):
+    """Test case for complexity tests."""
+
+    def assert_complexity_le(self, left: Expression, right: Expression) -> None:
+        """Assert that the complexity of the first expression is less than the second."""
+        self.assertIsInstance(left, Expression)
+        self.assertIsInstance(right, Expression)
+        self.assertLessEqual(complexity(left), complexity(right))
+
+    def assert_complexity_equal(self, left: Expression, right: Expression) -> None:
+        """Assert that the complexity of the first expression is less than the second."""
+        self.assertIsInstance(left, Expression)
+        self.assertIsInstance(right, Expression)
+        self.assertEqual(complexity(left), complexity(right))
+
+    def test_complexity_equal(self):
+        """Test complexity equivalence."""
+        examples = [
+            (P(A), P(B), "probability 1-variable isomorphism"),
+            (P(A, B), P(B, A), "probability 2-variable isomorphism, same variables"),
+            (P(A, B), P(B, C), "probability 2-variable isomorphism, one different"),
+            (P(A, B), P(C, D), "probability 2-variable isomorphism, two different"),
+        ]
+        for left, right, label in examples:
+            with self.subTest(label=label):
+                self.assert_complexity_equal(left, right)
+
+    def test_expand(self):
+        """Test various expansions always make at least more complicated expressions."""
+        examples = [
+            P(A | X),
+            P(A | X, Y),
+            P(A | X, Y, Z),
+            P(A, B | X),
+            P(A, B | X, Y),
+            P(A, B | X, Y, Z),
+        ]
+        for example in examples:
+            with self.subTest(expr=example.to_y0(), type="fraction"):
+                self.assert_complexity_le(example, fraction_expand(example))
+            with self.subTest(expr=example.to_y0(), type="bayes"):
+                self.assert_complexity_le(example, bayes_expand(example))
+            with self.subTest(expr=example.to_y0(), type="chain"):
+                self.assert_complexity_le(example, chain_expand(example))

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -10,7 +10,7 @@ of what's more complex by comparing expressions.
 import unittest
 
 from y0.complexity import complexity
-from y0.dsl import A, B, C, D, Expression, P, X, Y, Z
+from y0.dsl import A, B, C, D, Expression, Fraction, One, P, Product, X, Y, Z
 from y0.mutate import bayes_expand, chain_expand, fraction_expand
 
 
@@ -58,3 +58,14 @@ class TestComplexity(unittest.TestCase):
                 self.assert_complexity_le(example, bayes_expand(example))
             with self.subTest(expr=example.to_y0(), type="chain"):
                 self.assert_complexity_le(example, chain_expand(example))
+
+    def test_fraction_simplify(self):
+        """Test simplifying a fraction always results in at least a less complicated expression."""
+        examples = [
+            Fraction(P(A), One()),
+            Fraction(P(A) * P(B), P(B)),
+        ]
+        for example in examples:
+            with self.subTest(expr=example.to_y0()):
+                self.assertIsInstance(example, Fraction)
+                self.assert_complexity_le(example.simplify(), example)

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -10,8 +10,8 @@ of what's more complex by comparing expressions.
 import unittest
 
 from y0.complexity import complexity
-from y0.dsl import A, B, C, D, X, Y, Z, Expression, P
-from y0.mutate import fraction_expand, bayes_expand, chain_expand
+from y0.dsl import A, B, C, D, Expression, P, X, Y, Z
+from y0.mutate import bayes_expand, chain_expand, fraction_expand
 
 
 class TestComplexity(unittest.TestCase):

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -10,7 +10,7 @@ of what's more complex by comparing expressions.
 import unittest
 
 from y0.complexity import complexity
-from y0.dsl import A, B, C, D, Expression, Fraction, One, P, Product, X, Y, Z
+from y0.dsl import A, B, C, D, Expression, Fraction, One, P, X, Y, Z
 from y0.mutate import bayes_expand, chain_expand, fraction_expand
 
 


### PR DESCRIPTION
This PR adds a function `y0.complexity.complexity()` that takes any expression and returns a floating point value describing how complex the expression is, where bigger means more complex.

While the exact definition of complexity is up for debate, even an initial (albeit, naïve) implementation will give us the general ability to order a list of expressions.

This was motivated by our discussion yesterday where we wanted to have one or more metrics to sort a list of reduced graphs coming out of the experimental design algorithm.

CC @vartikatewari @srtaheri @djinnome 
