### PR TITLE
Fix graph types in design algorithm

### DIFF
--- a/src/y0/algorithm/simplify_latent.py
+++ b/src/y0/algorithm/simplify_latent.py
@@ -11,6 +11,7 @@ from typing import Iterable, Mapping, NamedTuple, Optional, Set, Tuple
 
 import networkx as nx
 
+from ..dsl import Variable
 from ..graph import DEFAULT_TAG
 
 __all__ = [
@@ -30,8 +31,8 @@ class SimplifyResults(NamedTuple):
     """Results from the simplification of a LV-DAG."""
 
     graph: nx.DiGraph
-    widows: Set[str]
-    redundant: Set[str]
+    widows: Set[Variable]
+    redundant: Set[Variable]
 
 
 def simplify_latent_dag(graph: nx.DiGraph, tag: Optional[str] = None):
@@ -50,7 +51,7 @@ def simplify_latent_dag(graph: nx.DiGraph, tag: Optional[str] = None):
     )
 
 
-def iter_latents(graph: nx.DiGraph, *, tag: Optional[str] = None) -> Iterable[str]:
+def iter_latents(graph: nx.DiGraph, *, tag: Optional[str] = None) -> Iterable[Variable]:
     """Iterate over nodes marked as latent.
 
     :param graph: A latent variable DAG
@@ -67,7 +68,7 @@ def iter_latents(graph: nx.DiGraph, *, tag: Optional[str] = None) -> Iterable[st
 
 def remove_widow_latents(
     graph: nx.DiGraph, tag: Optional[str] = None
-) -> Tuple[nx.DiGraph, Set[str]]:
+) -> Tuple[nx.DiGraph, Set[Variable]]:
     """Remove latents with no children (in-place).
 
     :param graph: A latent variable DAG
@@ -79,7 +80,7 @@ def remove_widow_latents(
     return graph, remove
 
 
-def iter_widow_latents(graph: nx.DiGraph, *, tag: Optional[str] = None) -> Iterable[str]:
+def iter_widow_latents(graph: nx.DiGraph, *, tag: Optional[str] = None) -> Iterable[Variable]:
     """Iterate over latent variables with no children.
 
     :param graph: A latent variable DAG
@@ -140,7 +141,7 @@ def _add_modified_latent(
 
 def iter_middle_latents(
     graph: nx.DiGraph, *, tag: Optional[str] = None
-) -> Iterable[Tuple[str, Set[str], Set[str]]]:
+) -> Iterable[Tuple[Variable, Set[Variable], Set[Variable]]]:
     """Iterate over latent nodes that have both parents and children (along with them).
 
     :param graph: A latent variable DAG
@@ -159,7 +160,7 @@ def iter_middle_latents(
 
 def remove_redundant_latents(
     graph: nx.DiGraph, tag: Optional[str] = None
-) -> Tuple[nx.DiGraph, Set[str]]:
+) -> Tuple[nx.DiGraph, Set[Variable]]:
     """Remove redundant latent variables.
 
     :param graph: A latent variable DAG
@@ -171,8 +172,8 @@ def remove_redundant_latents(
     return graph, remove
 
 
-def _iter_redundant_latents(graph, *, tag: Optional[str] = None) -> Iterable[str]:
-    latents: Mapping[str, Set[str]] = {
+def _iter_redundant_latents(graph: nx.DiGraph, *, tag: Optional[str] = None) -> Iterable[Variable]:
+    latents: Mapping[Variable, Set[Variable]] = {
         node: set(graph.successors(node)) for node in iter_latents(graph, tag=tag)
     }
     for (left, left_children), (right, right_children) in itt.product(latents.items(), repeat=2):

--- a/src/y0/algorithm/simplify_latent.py
+++ b/src/y0/algorithm/simplify_latent.py
@@ -112,7 +112,7 @@ def transform_latents_with_parents(
         graph.remove_node(latent_node)
         graph.add_edges_from(itt.product(parents, children))
 
-        new_node = f"{latent_node}{suffix}"
+        new_node = Variable(f"{latent_node}{suffix}")
         graph.add_node(new_node, **{tag: True})
         for child in children:
             graph.add_edge(new_node, child)

--- a/src/y0/algorithm/taheri_design.py
+++ b/src/y0/algorithm/taheri_design.py
@@ -45,8 +45,8 @@ class Result(NamedTuple):
     pre_edges: int
     post_nodes: int
     post_edges: int
-    latents: List[str]
-    observed: List[str]
+    latents: List[Variable]
+    observed: List[Variable]
     lvdag: nx.DiGraph
     admg: NxMixedGraph
 
@@ -150,8 +150,8 @@ def _help(
 
 def _get_result(
     lvdag: nx.DiGraph,
-    latents,
-    observed,
+    latents: Collection[Variable],
+    observed: Collection[Variable],
     cause: Variable,
     effect: Variable,
     *,
@@ -283,7 +283,7 @@ def draw_results(
             ax.axis("off")
         else:
             mixed_graph = result.admg
-            title = f"{i}) Latent: " + ", ".join(map(str, result.latents))
+            title = f"{i}) Latent: " + ", ".join(f"${v.to_latex()}$" for v in result.latents)
             if result.estimand is not None:
                 title += f"\n${result.estimand.to_latex()}$"
             mixed_graph.draw(ax=ax, title="\n".join(textwrap.wrap(title, width=45)))
@@ -304,7 +304,7 @@ def print_results(results: List[Result], file=None) -> None:
             result.post_nodes - result.pre_nodes,
             result.post_edges - result.pre_edges,
             len(result.latents),
-            ", ".join(result.latents),
+            ", ".join(f"${v.to_latex()}$" for v in result.latents),
         )
         for i, result in enumerate(results, start=1)
     ]

--- a/src/y0/algorithm/taheri_design.py
+++ b/src/y0/algorithm/taheri_design.py
@@ -94,8 +94,8 @@ def taheri_design_admg(
 
 def taheri_design_dag(
     graph: nx.DiGraph,
-    cause: str,
-    effect: str,
+    cause: Union[str, Variable],
+    effect: Union[str, Variable],
     *,
     tag: Optional[str] = None,
     stop: Optional[int] = None,
@@ -113,6 +113,8 @@ def taheri_design_dag(
     :param stop: Largest combination to get (None means length of the list and is the default)
     :return: A list of LV-DAG identifiability results. Will be length 2^(|V| - 2)
     """
+    cause = Variable.norm(cause)
+    effect= Variable.norm(effect)
     return _help(
         graph=graph,
         cause=cause,
@@ -125,11 +127,11 @@ def taheri_design_dag(
 
 def _help(
     graph: nx.DiGraph,
-    cause: str,
-    effect: str,
+    cause: Variable,
+    effect: Variable,
     *,
-    fixed_observed: Optional[Collection[str]] = None,
-    fixed_latent: Optional[Collection[str]] = None,
+    fixed_observed: Optional[Collection[Variable]] = None,
+    fixed_latent: Optional[Collection[Variable]] = None,
     tag: Optional[str] = None,
     stop: Optional[int] = None,
 ) -> List[Result]:
@@ -156,8 +158,8 @@ def _get_result(
     lvdag,
     latents,
     observed,
-    cause,
-    effect,
+    cause: Variable,
+    effect: Variable,
     *,
     tag: Optional[str] = None,
 ) -> Result:
@@ -177,7 +179,7 @@ def _get_result(
         raise KeyError(f"ADMG missing effect: {effect}")
 
     # Check if the ADMG is identifiable under the (simple) causal query
-    query = P(Variable(effect) @ ~Variable(cause))
+    query = P(effect @ ~cause)
     identifiable = is_identifiable(admg, query)
     try:
         estimand: Optional[Expression] = canonicalize(

--- a/src/y0/algorithm/taheri_design.py
+++ b/src/y0/algorithm/taheri_design.py
@@ -149,7 +149,7 @@ def _help(
 
 
 def _get_result(
-    lvdag,
+    lvdag: nx.DiGraph,
     latents,
     observed,
     cause: Variable,
@@ -228,13 +228,16 @@ def iterate_lvdags(
 
     if stop is None:
         stop = len(inducible_nodes) - 1
-    it: Iterable[Set[Variable]] = map(set, powerset(
-        sorted(inducible_nodes),
-        stop=stop,
-        reverse=True,
-        use_tqdm=True,
-        tqdm_kwargs=dict(desc="LV powerset"),
-    ))
+    it: Iterable[Set[Variable]] = map(
+        set,
+        powerset(
+            sorted(inducible_nodes),
+            stop=stop,
+            reverse=True,
+            use_tqdm=True,
+            tqdm_kwargs=dict(desc="LV powerset"),
+        ),
+    )
 
     graph = graph.copy()
     for node in fixed_observed:
@@ -279,8 +282,8 @@ def draw_results(
         if result is None:
             ax.axis("off")
         else:
-            mixed_graph = NxMixedGraph.from_admg(result.admg)  # type:ignore
-            title = f"{i}) Latent: " + ", ".join(result.latents)
+            mixed_graph = result.admg
+            title = f"{i}) Latent: " + ", ".join(map(str, result.latents))
             if result.estimand is not None:
                 title += f"\n${result.estimand.to_latex()}$"
             mixed_graph.draw(ax=ax, title="\n".join(textwrap.wrap(title, width=45)))

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -528,7 +528,7 @@ def set_latent(
     """Quickly set the latent variables in a graph."""
     if tag is None:
         tag = DEFAULT_TAG
-    if isinstance(latent_nodes, str):
+    if isinstance(latent_nodes, Variable):
         latent_nodes = [latent_nodes]
 
     latent_nodes = set(latent_nodes)

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -522,7 +522,7 @@ def _latent_dag(
 
 def set_latent(
     graph: nx.DiGraph,
-    latent_nodes: Union[str, Iterable[str]],
+    latent_nodes: Union[Variable, Iterable[Variable]],
     tag: Optional[str] = None,
 ) -> None:
     """Quickly set the latent variables in a graph."""

--- a/tests/test_algorithm/test_simplify_latent.py
+++ b/tests/test_algorithm/test_simplify_latent.py
@@ -13,7 +13,19 @@ from y0.algorithm.simplify_latent import (
     remove_widow_latents,
     transform_latents_with_parents,
 )
+from y0.algorithm.taheri_design import taheri_design_dag
+from y0.examples import igf_example
 from y0.graph import set_latent
+
+
+class TestDesign(unittest.TestCase):
+    """Test the design algorithm."""
+
+    def test_design(self):
+        """Test the design algorithm."""
+        results = taheri_design_dag(igf_example.graph.directed, cause="PI3K", effect="Erk", stop=3)
+        self.assertIsNotNone(results)
+        # FIXME do better than this.
 
 
 class TestSimplify(unittest.TestCase):

--- a/tests/test_algorithm/test_simplify_latent.py
+++ b/tests/test_algorithm/test_simplify_latent.py
@@ -14,7 +14,7 @@ from y0.algorithm.simplify_latent import (
     transform_latents_with_parents,
 )
 from y0.algorithm.taheri_design import taheri_design_dag
-from y0.dsl import Y1, Y2, Y3, U, Variable, W, Y, Z
+from y0.dsl import Y1, Y2, Y3, U, Variable, W
 from y0.examples import igf_example
 from y0.graph import set_latent
 

--- a/tests/test_algorithm/test_simplify_latent.py
+++ b/tests/test_algorithm/test_simplify_latent.py
@@ -14,8 +14,11 @@ from y0.algorithm.simplify_latent import (
     transform_latents_with_parents,
 )
 from y0.algorithm.taheri_design import taheri_design_dag
+from y0.dsl import Y1, Y2, Y3, U, Variable, W, Y, Z
 from y0.examples import igf_example
 from y0.graph import set_latent
+
+X1, X2, X3 = map(Variable, ["X1", "X2", "X3"])
 
 
 class TestDesign(unittest.TestCase):
@@ -53,30 +56,30 @@ class TestSimplify(unittest.TestCase):
         graph = nx.DiGraph()
         graph.add_edges_from(
             [
-                ("X1", "X2"),
-                ("X2", "W"),
-                ("U", "X2"),
-                ("U", "X3"),
-                ("U", "W"),
+                (X1, X2),
+                (X2, W),
+                (U, X2),
+                (U, X3),
+                (U, W),
             ]
         )
-        latents = {"U", "W"}
+        latents = {U, W}
         set_latent(graph, latents)
         self.assertEqual(latents, set(iter_latents(graph)))
 
         # Apply the simplification
         _, removed = remove_widow_latents(graph)
-        self.assertEqual({"W"}, removed)
+        self.assertEqual({W}, removed)
 
         expected = nx.DiGraph()
         expected.add_edges_from(
             [
-                ("X1", "X2"),
-                ("U", "X2"),
-                ("U", "X3"),
+                (X1, X2),
+                (U, X2),
+                (U, X3),
             ]
         )
-        set_latent(expected, "U")
+        set_latent(expected, U)
 
         self.assert_latent_variable_dag_equal(expected, graph)
 
@@ -85,32 +88,32 @@ class TestSimplify(unittest.TestCase):
         graph = nx.DiGraph()
         graph.add_edges_from(
             [
-                ("X1", "U"),
-                ("X2", "U"),
-                ("U", "Y1"),
-                ("U", "Y2"),
-                ("U", "Y3"),
+                (X1, U),
+                (X2, U),
+                (U, Y1),
+                (U, Y2),
+                (U, Y3),
             ]
         )
-        set_latent(graph, "U")
+        set_latent(graph, U)
         # Apply the simplification
         transform_latents_with_parents(graph)
 
         expected = nx.DiGraph()
         expected.add_edges_from(
             [
-                ("X1", "Y1"),
-                ("X1", "Y2"),
-                ("X1", "Y3"),
-                ("X2", "Y1"),
-                ("X2", "Y2"),
-                ("X2", "Y3"),
-                (f"U{DEFAULT_SUFFIX}", "Y1"),
-                (f"U{DEFAULT_SUFFIX}", "Y2"),
-                (f"U{DEFAULT_SUFFIX}", "Y3"),
+                (X1, Y1),
+                (X1, Y2),
+                (X1, Y3),
+                (X2, Y1),
+                (X2, Y2),
+                (X2, Y3),
+                (Variable(f"U{DEFAULT_SUFFIX}"), Y1),
+                (Variable(f"U{DEFAULT_SUFFIX}"), Y2),
+                (Variable(f"U{DEFAULT_SUFFIX}"), Y3),
             ]
         )
-        set_latent(expected, f"U{DEFAULT_SUFFIX}")
+        set_latent(expected, Variable(f"U{DEFAULT_SUFFIX}"))
 
         self.assert_latent_variable_dag_equal(expected, graph)
 
@@ -119,25 +122,25 @@ class TestSimplify(unittest.TestCase):
         graph = nx.DiGraph()
         graph.add_edges_from(
             [
-                ("U", "X1"),
-                ("U", "X2"),
-                ("U", "X3"),
-                ("W", "X1"),
-                ("W", "X2"),
+                (U, X1),
+                (U, X2),
+                (U, X3),
+                (W, X1),
+                (W, X2),
             ]
         )
-        set_latent(graph, ["U", "W"])
+        set_latent(graph, [U, W])
         # Apply the simplification
         remove_redundant_latents(graph)
 
         expected = nx.DiGraph()
         expected.add_edges_from(
             [
-                ("U", "X1"),
-                ("U", "X2"),
-                ("U", "X3"),
+                (U, X1),
+                (U, X2),
+                (U, X3),
             ]
         )
-        set_latent(expected, ["U"])
+        set_latent(expected, [U])
 
         self.assert_latent_variable_dag_equal(expected, graph)


### PR DESCRIPTION
When we made all graphs forced to have variable nodes, the design algorithm wasn't tested and we didn't notice. This PR adds a test that it can be run and then updates the code accordingly