### PR TITLE
Add `NxMixedGraph.subgraph_without()`

### DIFF
--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -392,6 +392,11 @@ class NxMixedGraph:
             undirected=_include_adjacent(self.undirected, vertices),
         )
 
+    def subgraph_without(self, vertices: Union[Variable, Iterable[Variable]]) -> NxMixedGraph:
+        """Return a subgraph without a set of vertices."""
+        vertices = _ensure_set(vertices)
+        return self.subgraph(self.nodes() - vertices)
+
     def remove_in_edges(self, vertices: Union[Variable, Iterable[Variable]]) -> NxMixedGraph:
         """Return a mutilated graph given a set of interventions.
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -138,6 +138,7 @@ class TestGraph(unittest.TestCase):
 
         subgraph = NxMixedGraph.from_str_edges(directed=[("X", "Y")])
         self.assertEqual(subgraph, graph.subgraph({X, Y}))
+        self.assertEqual(subgraph, graph.subgraph_without({Z}))
 
     def test_intervention(self):
         """Test generating a subgraph based on an intervention."""


### PR DESCRIPTION
This utility is a shortcut for `graph.subgraph(graph.nodes() - vertices)`