### PR TITLE
Add `NxMixedGraph.get_district()`

### DIFF
--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -454,6 +454,13 @@ class NxMixedGraph:
         """Get the districts."""
         return {frozenset(c) for c in nx.connected_components(self.undirected)}
 
+    def get_district(self, node: Variable) -> frozenset[Variable]:
+        """Get the district the node is in."""
+        for district in self.districts():
+            if node in district:
+                return district
+        raise KeyError
+
     def is_connected(self) -> bool:
         """Return if there is only a single connected component in the undirected graph."""
         return nx.is_connected(self.undirected)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -220,6 +220,15 @@ class TestGraph(unittest.TestCase):
             )
             self.assertEqual(components, actual_components)
 
+    def test_get_district(self):
+        """Test getting districts."""
+        graph = NxMixedGraph().from_edges(directed=[(X, M), (M, Y)], undirected=[(X, Y)])
+        self.assertEqual(frozenset([X, Y]), graph.get_district(X))
+        self.assertEqual(frozenset([X, Y]), graph.get_district(Y))
+        self.assertEqual(frozenset([M]), graph.get_district(M))
+        with self.assertRaises(KeyError):
+            graph.get_district(Z)
+
     def test_counterfactual_predicate(self):
         """Test checking counterfactual graph."""
         graph = NxMixedGraph.from_edges(directed=[(X, Y)])


### PR DESCRIPTION
This allows for quickly getting the district (i.e., c-component) that a given node is in