### PR TITLE
Improve safe sums and products

### DIFF
--- a/src/y0/algorithm/identify/id_std.py
+++ b/src/y0/algorithm/identify/id_std.py
@@ -57,8 +57,6 @@ def identify(identification: Identification) -> Expression:
         parents = list(graph.topological_sort())
         expression = Product.safe(p_parents(v, parents) for v in district_without_treatment)
         ranges = district_without_treatment - outcomes
-        if not ranges:
-            return expression
         return Sum.safe(
             expression=expression,
             ranges=ranges,
@@ -245,8 +243,6 @@ def line_6(identification: Identification) -> Expression:
     parents = list(graph.topological_sort())
     expression = Product.safe(p_parents(v, parents) for v in district_without_treatments)
     ranges = district_without_treatments - outcomes
-    if not ranges:
-        return expression
     return Sum.safe(
         expression=expression,
         ranges=ranges,

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -483,12 +483,12 @@ class TestSafeConstructors(unittest.TestCase):
 
     def test_product(self):
         """Test the :meth:`Product.safe` constructor."""
-        p = P(X, Y)
-        self.assertEqual(Product((p,)), Product.safe(p))
-        self.assertEqual(Product((p,)), Product.safe((p,)))
-        self.assertEqual(Product((p,)), Product.safe([p]))
-        self.assertEqual(Product((p,)), Product.safe({p}))
-
+        p1 = P(X, Y)
+        p2 = P(Z)
+        self.assertEqual(p1, Product.safe(p1))
+        self.assertEqual(p1, Product.safe([p1]))
+        self.assertEqual(Product((p1, p2)), Product.safe((p1, p2)))
+        self.assertEqual(Product((p1, p2)), Product.safe([p1, p2]))
         self.assertEqual(Product((P(X), P(Y))), Product.safe(P(v) for v in [X, Y]))
 
 


### PR DESCRIPTION
This PR does the following:

1. If you use `Sum.safe` but there's no ranges, then it returns the original expression
2. If you use `Product.safe` but there's only one expression, it returns it