### PR TITLE
Add missing scenario for empty products

### DIFF
--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -909,7 +909,7 @@ class Product(Expression):
 
         :param expressions: An expression or iterable of expressions which should be multiplied
         :returns: A :class:`Product` object
-        :raises NotImplementedError: If an empty list of expressions is returned
+        :raises ValueError: If an empty iterable of expressions is input
 
         Standard usage, same as the normal ``__init__``:
 

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -909,6 +909,7 @@ class Product(Expression):
 
         :param expressions: An expression or iterable of expressions which should be multiplied
         :returns: A :class:`Product` object
+        :raises NotImplementedError: If an empty list of expressions is returned
 
         Standard usage, same as the normal ``__init__``:
 
@@ -930,6 +931,11 @@ class Product(Expression):
         if isinstance(expressions, Expression):
             return expressions
         expressions = tuple(expressions)
+        if not expressions:
+            raise NotImplementedError(
+                "Product.safe has not been implement to handle empty list of expressions. "
+                "Should this return One()? Please let us know."
+            )
         if len(expressions) == 1:
             return expressions[0]
         return cls(expressions=expressions)

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -932,9 +932,9 @@ class Product(Expression):
             return expressions
         expressions = tuple(expressions)
         if not expressions:
-            raise NotImplementedError(
-                "Product.safe has not been implement to handle empty list of expressions. "
-                "Should this return One()? Please let us know."
+            raise ValueError(
+                "Product.safe does not explicitly empty list of expressions. "
+                "Should this return One()? Or Zero()? Please let us know."
             )
         if len(expressions) == 1:
             return expressions[0]

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -491,6 +491,9 @@ class TestSafeConstructors(unittest.TestCase):
         self.assertEqual(Product((p1, p2)), Product.safe([p1, p2]))
         self.assertEqual(Product((P(X), P(Y))), Product.safe(P(v) for v in [X, Y]))
 
+        with self.assertRaises(NotImplementedError):
+            Product.safe([])
+
 
 zero = Zero()
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -491,7 +491,7 @@ class TestSafeConstructors(unittest.TestCase):
         self.assertEqual(Product((p1, p2)), Product.safe([p1, p2]))
         self.assertEqual(Product((P(X), P(Y))), Product.safe(P(v) for v in [X, Y]))
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(ValueError):
             Product.safe([])
 
 


### PR DESCRIPTION
As a follow-up to #159, this PR raises an exception if `Product.safe` is called with an empty collection.