### PR TITLE
Make DSL construction safer

### DIFF
--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -661,7 +661,7 @@ class Expression(Element, ABC):
         """Return this expression, normalized by this expression marginalized by the given variables."""
         return self / self.marginalize(ranges)
 
-    def marginalize(self, ranges: VariableHint) -> Sum:
+    def marginalize(self, ranges: VariableHint) -> Expression:
         """Return this expression, marginalizing out the given variables.
 
         :param ranges: A variable or list of variables over which to marginalize this expression
@@ -671,7 +671,7 @@ class Expression(Element, ABC):
         >>> assert P(A, B).marginalize(A) == Sum[A](P(A, B))
         >>> assert P(A, B, C).marginalize([A, B]) == Sum[A, B](P(A, B, C))
         """
-        return Sum(
+        return Sum.safe(
             expression=self,
             ranges=_upgrade_ordering([r.get_base() for r in _upgrade_variables(ranges)]),
         )

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -996,6 +996,9 @@ class Sum(Expression):
     def __post_init__(self):
         if not self.ranges:
             raise ValueError("Sum must have ranges")
+        for r in self.ranges:
+            if isinstance(r, (CounterfactualVariable, Intervention)):
+                raise TypeError(f"Ranges must not be counterfactuals nor interventions")
 
     @classmethod
     def safe(

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -1184,13 +1184,13 @@ class Fraction(Expression):
         new_numerator, new_denominator = cls._simplify_parts_helper(numerator, denominator)
         if new_numerator and new_denominator:
             return Fraction(
-                _expression_or_product(new_numerator),
-                _expression_or_product(new_denominator),
+                Product.safe(new_numerator),
+                Product.safe(new_denominator),
             )
         elif new_numerator:
-            return _expression_or_product(new_numerator)
+            return Product.safe(new_numerator)
         elif new_denominator:
-            return One() / _expression_or_product(new_denominator)
+            return One() / Product.safe(new_denominator)
         else:
             return One()
 
@@ -1213,14 +1213,6 @@ class Fraction(Expression):
             tuple(expr for i, expr in enumerate(numerator) if i not in numerator_cancelled),
             tuple(expr for i, expr in enumerate(denominator) if i not in denominator_cancelled),
         )
-
-
-def _expression_or_product(e: Sequence[Expression]) -> Expression:
-    if not e:
-        raise ValueError
-    if 1 == len(e):
-        return e[0]
-    return Product(tuple(e))
 
 
 class One(Expression):

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -998,7 +998,7 @@ class Sum(Expression):
             raise ValueError("Sum must have ranges")
         for r in self.ranges:
             if isinstance(r, (CounterfactualVariable, Intervention)):
-                raise TypeError(f"Ranges must not be counterfactuals nor interventions")
+                raise TypeError("Ranges must not be counterfactuals nor interventions")
 
     @classmethod
     def safe(

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -930,7 +930,11 @@ class Product(Expression):
         """
         if isinstance(expressions, Expression):
             return expressions
-        expressions = tuple(expressions)
+        # Remove multiplications of one
+        expressions = tuple(expression for expression in expressions if expression != One())
+        # If any multiplications are by zero, then return zero
+        if any(expression == Zero() for expression in expressions):
+            return Zero()
         if not expressions:
             raise ValueError(
                 "Product.safe does not explicitly empty list of expressions. "

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -991,7 +991,7 @@ class Sum(Expression):
     #: The expression over which the sum is done
     expression: Expression
     #: The variables over which the sum is done. Defaults to an empty list, meaning no variables.
-    ranges: Tuple[Variable, ...] = field(default_factory=tuple)
+    ranges: Tuple[Variable, ...]
 
     def __post_init__(self):
         if not self.ranges:

--- a/src/y0/mutate/canonicalize_expr.py
+++ b/src/y0/mutate/canonicalize_expr.py
@@ -3,7 +3,7 @@
 """Implementation of the canonicalization algorithm."""
 
 from operator import attrgetter
-from typing import Iterable, Mapping, Optional, Sequence, Tuple, Union
+from typing import Collection, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
 from ..dsl import (
     CounterfactualVariable,
@@ -69,7 +69,7 @@ class Canonicalizer:
             )
         )
 
-    def _sorted(self, variables: Tuple[Variable, ...]) -> Tuple[Variable, ...]:
+    def _sorted(self, variables: Collection[Variable]) -> Tuple[Variable, ...]:
         return tuple(
             sorted(
                 (self._canonicalize_variable(variable) for variable in variables),
@@ -102,7 +102,7 @@ class Canonicalizer:
         elif isinstance(expression, Sum):
             if not expression.ranges:  # flatten unnecessary sum
                 return self.canonicalize(expression.expression)
-            return Sum(
+            return Sum.safe(
                 expression=self.canonicalize(expression.expression),
                 ranges=self._sorted(expression.ranges),
             )

--- a/src/y0/parser/ce/grammar.py
+++ b/src/y0/parser/ce/grammar.py
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 expr = Forward()
 
 
-def _make_sum(_s, _l, tokens: ParseResults) -> Sum:
-    return Sum(
+def _make_sum(_s, _l, tokens: ParseResults) -> Expression:
+    return Sum.safe(
         ranges=_sorted_variables(tokens["ranges"].asList() if "ranges" in tokens else []),
         expression=tokens["expression"],
     )

--- a/src/y0/parser/craig/grammar.py
+++ b/src/y0/parser/craig/grammar.py
@@ -24,8 +24,8 @@ __all__ = [
 expr = Forward()
 
 
-def _make_sum(_s, _l, tokens: ParseResults) -> Sum:
-    return Sum(
+def _make_sum(_s, _l, tokens: ParseResults) -> Expression:
+    return Sum.safe(
         ranges=tuple(tokens["ranges"].asList()) if "ranges" in tokens else tuple(),
         expression=tokens["expression"],
     )

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -467,6 +467,22 @@ class TestSafeConstructors(unittest.TestCase):
         with self.assertRaises(ValueError):
             Product.safe([])
 
+        self.assertEqual(Product((P(X), P(Y))), Product.safe((One(), P(X), P(Y))))
+        self.assertEqual(Product((P(X), P(Y))), Product.safe((P(X), P(Y))))
+        self.assertEqual(Product((P(X), P(Y))), Product.safe((P(X), One(), P(Y))))
+        self.assertEqual(Product((P(X), P(Y))), Product.safe((P(X), P(Y), One(), One())))
+        self.assertEqual(Product((P(X), P(Y))), Product.safe((P(X), One(), P(Y), One(), One())))
+
+        self.assertEqual(P(X), Product.safe((One(), P(X))))
+        self.assertEqual(P(X), Product.safe((P(X),)))
+        self.assertEqual(P(X), Product.safe((P(X), One())))
+        self.assertEqual(P(X), Product.safe((P(X), One(), One())))
+        self.assertEqual(P(X), Product.safe((P(X), One(), One(), One())))
+
+        self.assertEqual(Zero(), Product.safe((P(X), Zero())))
+        self.assertEqual(Zero(), Product.safe((P(X), Zero(), One())))
+        self.assertEqual(Zero(), Product.safe((Zero(), One())))
+
 
 zero = Zero()
 

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -266,6 +266,13 @@ class TestDSL(unittest.TestCase):
 
     def test_sum(self):
         """Test the Sum DSL object."""
+        with self.assertRaises(TypeError):
+            Sum(P(A), (~B,))
+        with self.assertRaises(TypeError):
+            Sum(P(A), (B @ C,))
+        with self.assertRaises(ValueError):
+            Sum(P(A), tuple())
+
         # Sum with one variable
         self.assert_text(
             "[ sum_{S} P(A | B) P(C | D) ]",


### PR DESCRIPTION
- raise errors when giving non-symbols as ranges to sums
- remove default constructor for `ranges` in the `Sum` class
- use `Sum.safe()` in several other places
- Improve `Product.safe()` to handle multiplication by one or zero