### PR TITLE
Fix bug in expansion functions

### DIFF
--- a/src/y0/mutate/chain.py
+++ b/src/y0/mutate/chain.py
@@ -129,7 +129,7 @@ def bayes_expand(p: Probability) -> Expression:
         return p
     warnings.warn(
         "Bayes expansion is now auto-normalized to fraction expansion "
-        "since introducting new rules in Sum.safe in "
+        "since introducing new rules in Sum.safe in "
         "https://github.com/y0-causal-inference/y0/pull/159. Simply use fraction_expand() instead",
         DeprecationWarning,
         stacklevel=2,

--- a/src/y0/mutate/chain.py
+++ b/src/y0/mutate/chain.py
@@ -72,7 +72,7 @@ def chain_expand(p: Probability, *, reorder: bool = True, ordering: OrderingHint
     )
 
 
-def fraction_expand(p: Probability) -> Fraction:
+def fraction_expand(p: Probability) -> Expression:
     r"""Expand a probability distribution with fractions.
 
     :param p: The given probability expression
@@ -83,11 +83,22 @@ def fraction_expand(p: Probability) -> Fraction:
     .. math::
         P(A | B) = \frac{P(A,B)}{P(B)}
 
+    >>> from y0.dsl import P, A, B, Sum
+    >>> from y0.mutate.chain import fraction_expand
+    >>> assert fraction_expand(P(A | B)) == P(A, B) / P(B)
+
+    If there are no conditions (i.e., parents), then the probability
+    is returned without modification.
+
+    >>> assert fraction_expand(P(A, B)) == P(A, B)
+
     In general, with many children $Y_i$ and many parents $X_i$:
 
     .. math::
         P(Y_1,\dots,Y_n | X_1, \dots, X_m) = \frac{P(Y_1,\dots,Y_n,X_1,\dots,X_m)}{P(X_1,\dots,X_m)}
     """
+    if not p.parents:
+        return p
     return Fraction(p.uncondition(), P(p.parents))
 
 

--- a/src/y0/mutate/chain.py
+++ b/src/y0/mutate/chain.py
@@ -101,6 +101,17 @@ def bayes_expand(p: Probability) -> Expression:
         P(Y_1,\dots,Y_n|X_1,\dots,X_m)
         = \frac{P(Y_1,\dots,Y_n,X_1,\dots,X_m)}{\sum_{Y_1,\dots,Y_n} P(Y_1,\dots,Y_n,X_1,\dots,X_m)}
 
+    >>> from y0.dsl import P, A, B, C, Sum
+    >>> from y0.mutate.chain import bayes_expand
+    >>> assert bayes_expand(P(A | B)) == P(A, B) / Sum[A](P(A, B)
+
+    If there are no conditions (i.e., parents), then the probability
+    is returned without modification.
+
+    >>> assert bayes_expand(P(A, B)) == P(A, B)
+
     .. note:: This expansion will create a different but equal expression to :func:`fraction_expand`.
     """
+    if not p.parents:
+        return p
     return p.uncondition().normalize_marginalize(p.children)

--- a/src/y0/mutate/chain.py
+++ b/src/y0/mutate/chain.py
@@ -2,6 +2,8 @@
 
 """Operations for mutating and simplifying expressions."""
 
+import warnings
+
 from ..dsl import (
     Distribution,
     Expression,
@@ -125,4 +127,11 @@ def bayes_expand(p: Probability) -> Expression:
     """
     if not p.parents:
         return p
+    warnings.warn(
+        "Bayes expansion is now auto-normalized to fraction expansion "
+        "since introducting new rules in Sum.safe in "
+        "https://github.com/y0-causal-inference/y0/pull/159. Simply use fraction_expand() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return p.uncondition().normalize_marginalize(p.children)

--- a/tests/test_mutate/test_chain.py
+++ b/tests/test_mutate/test_chain.py
@@ -43,6 +43,7 @@ class TestChain(unittest.TestCase):
 
     def test_bayes_expand(self):
         """Test expanding a conditional using extended Bayes' Theorem."""
+        self.assertEqual(P(A, X), bayes_expand(P(A, X)))
         self.assertEqual(P(A, X) / Sum[A](P(A, X)), bayes_expand(P(A | X)))
         self.assertEqual(P(A, X, Y) / Sum[A](P(A, X, Y)), bayes_expand(P(A | (X, Y))))
         self.assertEqual(P(A, B, X, Y) / Sum[A, B](P(A, B, X, Y)), bayes_expand(P(A & B | (X, Y))))

--- a/tests/test_mutate/test_chain.py
+++ b/tests/test_mutate/test_chain.py
@@ -38,6 +38,7 @@ class TestChain(unittest.TestCase):
 
     def test_fraction_expand(self):
         """Test expanding a conditional probability with Bayes' Theorem."""
+        self.assertEqual(P(A, X), fraction_expand(P(A, X)))
         self.assertEqual(P(A, B) / P(B), fraction_expand(P(A | B)))
         self.assertEqual(P(W, X, Y, Z) / P(X, Y, Z), fraction_expand(P(W | (X, Y, Z))))
 


### PR DESCRIPTION
Both the bayes expansion and fraction expansion functions had the issue where they were making regular unconditioned joint probabilities more complicated