### PR TITLE
Improve probability strings

### DIFF
--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -720,7 +720,10 @@ class Probability(Expression):
         # check that there's only one intervention set and that it's not an empty one
         if len(intervention_sets) == 1 and (interventions := intervention_sets.pop()):
             # only keep the + if necessary, otherwise show regular
-            intervention_str = _list_to_y0(i.get_base() if not i.star else i for i in interventions)
+            intervention_str = ",".join(
+                f"+{intervention.name}" if intervention.star else intervention.name
+                for intervention in interventions
+            )
             unintervened_distribution = Distribution(
                 parents=tuple(Variable(name=v.name, star=v.star) for v in self.parents),
                 children=tuple(Variable(name=v.name, star=v.star) for v in self.children),

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -712,6 +712,20 @@ class Probability(Expression):
 
     def to_y0(self) -> str:
         """Output this probability instance as y0 internal DSL code."""
+        # if all parts of distribution have same intervention set, then put it out front
+        intervention_sets = {
+            x.interventions if isinstance(x, CounterfactualVariable) else tuple()
+            for x in itt.chain(self.children, self.parents)
+        }
+        # check that there's only one intervention set and that it's not an empty one
+        if len(intervention_sets) == 1 and (interventions := intervention_sets.pop()):
+            # only keep the + if necessary, otherwise show regular
+            intervention_str = _list_to_y0(i.get_base() if not i.star else i for i in interventions)
+            unintervened_distribution = Distribution(
+                parents=tuple(Variable(name=v.name, star=v.star) for v in self.parents),
+                children=tuple(Variable(name=v.name, star=v.star) for v in self.children),
+            )
+            return f"P[{intervention_str}]({unintervened_distribution.to_y0()})"
         return f"P({self.distribution.to_y0()})"
 
     def to_latex(self) -> str:

--- a/src/y0/dsl.py
+++ b/src/y0/dsl.py
@@ -196,7 +196,12 @@ class Variable(Element):
 
     def to_y0(self) -> str:
         """Output this variable instance as y0 internal DSL code."""
-        return self.name
+        if self.star is None:
+            return self.name
+        elif self.star:
+            return f"+{self.name}"
+        else:
+            return f"-{self.name}"
 
     def intervene(self, variables: VariableHint) -> CounterfactualVariable:
         """Intervene on this variable with the given variable(s).

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -118,25 +118,25 @@ class TestDSL(unittest.TestCase):
         """Tests for generalized counterfactual variables."""
         for expr, expected in [
             # Single variable
-            (P(Y @ X), "P(Y @ -X)"),
-            (P(Y @ -X), "P(Y @ -X)"),
-            (P(Y @ ~X), "P(Y @ +X)"),
-            (P(Y @ +X), "P(Y @ +X)"),
+            (P(Y @ X), "P[X](Y)"),
+            (P(Y @ -X), "P[X](Y)"),
+            (P(Y @ ~X), "P[+X](Y)"),
+            (P(Y @ +X), "P[+X](Y)"),
             #
-            (P(-Y @ X), "P(-Y @ -X)"),
-            (P(-Y @ -X), "P(-Y @ -X)"),
-            (P(-Y @ ~X), "P(-Y @ +X)"),
-            (P(-Y @ +X), "P(-Y @ +X)"),
+            (P(-Y @ X), "P[X](-Y)"),
+            (P(-Y @ -X), "P[X](-Y)"),
+            (P(-Y @ ~X), "P[+X](-Y)"),
+            (P(-Y @ +X), "P[+X](-Y)"),
             #
-            (P(~Y @ X), "P(+Y @ -X)"),
-            (P(~Y @ -X), "P(+Y @ -X)"),
-            (P(~Y @ ~X), "P(+Y @ +X)"),
-            (P(~Y @ +X), "P(+Y @ +X)"),
+            (P(~Y @ X), "P[X](+Y)"),
+            (P(~Y @ -X), "P[X](+Y)"),
+            (P(~Y @ ~X), "P[+X](+Y)"),
+            (P(~Y @ +X), "P[+X](+Y)"),
             #
-            (P(+Y @ X), "P(+Y @ -X)"),
-            (P(+Y @ -X), "P(+Y @ -X)"),
-            (P(+Y @ ~X), "P(+Y @ +X)"),
-            (P(+Y @ +X), "P(+Y @ +X)"),
+            (P(+Y @ X), "P[X](+Y)"),
+            (P(+Y @ -X), "P[X](+Y)"),
+            (P(+Y @ ~X), "P[+X](+Y)"),
+            (P(+Y @ +X), "P[+X](+Y)"),
             # Interventions can live inside the conditions
             (P(Y @ X | ~X, ~Y), "P(Y @ -X | +X, +Y)"),
             (P(Y @ -X | ~X, ~Y), "P(Y @ -X | +X, +Y)"),
@@ -435,6 +435,30 @@ class TestCounterfactual(unittest.TestCase):
                 self.assertIsInstance(expr, CounterfactualVariable)
                 self.assertTrue(expr.is_event())
                 self.assertEqual(status, expr.is_inconsistent())
+
+    def test_counterfactual_y0(self):
+        """Test compressed output."""
+        self.assertEqual("P[X](Y)", P(Y @ X).to_y0())
+        self.assertEqual("P[X](Y)", P[X](Y).to_y0())
+        self.assertEqual("P[X](Y)", P(Y @ -X).to_y0())
+        self.assertEqual("P[X](Y)", P[-X](Y).to_y0())
+        self.assertEqual("P[X](Y)", P(Y @ ~X).to_y0())
+        self.assertEqual("P[X](Y)", P[~X](Y).to_y0())
+
+        self.assertEqual("P[+X](Y)", P(Y @ +X).to_y0())
+        self.assertEqual("P[+X](Y)", P[+X](Y).to_y0())
+
+        # Two variables, same intervention
+        self.assertEqual("P[X](Y, Z)", P(Y @ X, Z @ X).to_y0())
+        self.assertEqual("P[X](Y, Z)", P[X](Y, Z).to_y0())
+        self.assertEqual("P[X](Y, Z)", P(Y @ -X, Z @ -X).to_y0())
+        self.assertEqual("P[X](Y, Z)", P[-X](Y, Z).to_y0())
+        self.assertEqual("P[X](Y, Z)", P(Y @ ~X, Z @ ~X).to_y0())
+        self.assertEqual("P[X](Y, Z)", P[~X](Y, Z).to_y0())
+
+        # Two variables, mixed intervention
+        self.assertEqual("P(Y @ X, Z @ A)", P(Y @ X, Z @ A).to_y0())
+        self.assertEqual("P(Y @ X, Z @ +Z)", P(Y @ -X, Z @ +Z).to_y0())
 
 
 class TestSafeConstructors(unittest.TestCase):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -457,8 +457,8 @@ class TestCounterfactual(unittest.TestCase):
         self.assertEqual("P[+X](Y, Z)", P[~X](Y, Z).to_y0())
 
         # Two variables, mixed intervention
-        self.assertEqual("P(Y @ X, Z @ A)", P(Y @ X, Z @ A).to_y0())
-        self.assertEqual("P(Y @ X, Z @ +Z)", P(Y @ -X, Z @ +Z).to_y0())
+        self.assertEqual("P(Y @ -X, Z @ -A)", P(Y @ X, Z @ A).to_y0())
+        self.assertEqual("P(Y @ -X, Z @ +Z)", P(Y @ -X, Z @ +Z).to_y0())
 
 
 class TestSafeConstructors(unittest.TestCase):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -442,8 +442,8 @@ class TestCounterfactual(unittest.TestCase):
         self.assertEqual("P[X](Y)", P[X](Y).to_y0())
         self.assertEqual("P[X](Y)", P(Y @ -X).to_y0())
         self.assertEqual("P[X](Y)", P[-X](Y).to_y0())
-        self.assertEqual("P[X](Y)", P(Y @ ~X).to_y0())
-        self.assertEqual("P[X](Y)", P[~X](Y).to_y0())
+        self.assertEqual("P[+X](Y)", P(Y @ ~X).to_y0())
+        self.assertEqual("P[+X](Y)", P[~X](Y).to_y0())
 
         self.assertEqual("P[+X](Y)", P(Y @ +X).to_y0())
         self.assertEqual("P[+X](Y)", P[+X](Y).to_y0())
@@ -453,8 +453,8 @@ class TestCounterfactual(unittest.TestCase):
         self.assertEqual("P[X](Y, Z)", P[X](Y, Z).to_y0())
         self.assertEqual("P[X](Y, Z)", P(Y @ -X, Z @ -X).to_y0())
         self.assertEqual("P[X](Y, Z)", P[-X](Y, Z).to_y0())
-        self.assertEqual("P[X](Y, Z)", P(Y @ ~X, Z @ ~X).to_y0())
-        self.assertEqual("P[X](Y, Z)", P[~X](Y, Z).to_y0())
+        self.assertEqual("P[+X](Y, Z)", P(Y @ ~X, Z @ ~X).to_y0())
+        self.assertEqual("P[+X](Y, Z)", P[~X](Y, Z).to_y0())
 
         # Two variables, mixed intervention
         self.assertEqual("P(Y @ X, Z @ A)", P(Y @ X, Z @ A).to_y0())


### PR DESCRIPTION
This PR updates the way that probabilities are stringified. In the scenario where all parents and children of a probability have the same set of interventions, this is extracted and put into bracket notation

1. `P(A @ X, B @ X)` becomes `P[X](A, B)`
2. `P(A @ X, B @ Y)` remains unchanged because the interventions are different
3. `P(A @ X, B @ X | C @ X)` becomes `P[X](A, B | C)`
4. `P(A @ X, B @ Y | C @ X)` and `P(A @ X, B @ X | C @ Y)` remain unchanged because the interventions are different