### PR TITLE
Fix calculating conditional independence

### DIFF
--- a/src/y0/algorithm/falsification.py
+++ b/src/y0/algorithm/falsification.py
@@ -99,7 +99,7 @@ def get_falsifications(
         # and the second being the p-value. The other methods return a triple with the first element
         # being the Chi^2 statistic, the second being the p-value, and the third being the degrees of
         # freedom.
-        if method == 'pearson':
+        if method == "pearson":
             stat, p_value = result
             dof = None
         else:

--- a/src/y0/algorithm/falsification.py
+++ b/src/y0/algorithm/falsification.py
@@ -91,23 +91,32 @@ def get_falsifications(
     """
     if significance_level is None:
         significance_level = 0.05
-    variances = {
-        judgement: judgement.test(df, method=method)
-        for judgement in tqdm(judgements, disable=not verbose, desc="Checking conditionals")
-    }
-    evidence = pd.DataFrame(
-        [
+    # Make this loop explicit for clarity
+    results = []
+    for judgement in tqdm(judgements, disable=not verbose, desc="Checking conditionals"):
+        result = judgement.test(df, method=method)
+        # Person's correlation returns a pair with the first element being the Person's correlation
+        # and the second being the p-value. The other methods return a triple with the first element
+        # being the Chi^2 statistic, the second being the p-value, and the third being the degrees of
+        # freedom.
+        if method == 'pearson':
+            stat, p_value = result
+            dof = None
+        else:
+            stat, p_value, dof = result
+        results.append(
             (
                 judgement.left.name,
                 judgement.right.name,
                 "|".join(c.name for c in judgement.conditions),
-                chi,
-                p,
+                stat,
+                p_value,
                 dof,
             )
-            for judgement, (chi, p, dof) in variances.items()
-        ],
-        columns=["left", "right", "given", "chi^2", "p", "dof"],
+        )
+    evidence = pd.DataFrame(
+        results,
+        columns=["left", "right", "given", "stats", "p", "dof"],
     )
     evidence.sort_values("p", ascending=True, inplace=True)
     evidence = (

--- a/src/y0/algorithm/falsification.py
+++ b/src/y0/algorithm/falsification.py
@@ -92,7 +92,7 @@ def get_falsifications(
     if significance_level is None:
         significance_level = 0.05
     variances = {
-        judgement: judgement.test(df, test=method)
+        judgement: judgement.test(df, method=method)
         for judgement in tqdm(judgements, disable=not verbose, desc="Checking conditionals")
     }
     evidence = pd.DataFrame(

--- a/src/y0/struct.py
+++ b/src/y0/struct.py
@@ -6,16 +6,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import (
-    Callable,
-    Iterable,
-    Literal,
-    NamedTuple,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
 )
+from typing import Callable, Iterable, Literal, NamedTuple, Optional, Tuple, Union
 
 import pandas as pd
 
@@ -69,7 +61,7 @@ CITest = Literal[
     "neyman",
 ]
 
-CITestFunc = TypeVar("CITestFunc", bound=Callable)
+CITestFunc = Callable
 
 
 @lru_cache
@@ -136,7 +128,7 @@ class DSeparationJudgement:
 
     def test(
         self, df: pd.DataFrame, boolean: bool = False, method: Optional[CITest] = None, **kwargs
-    ) -> Union[Tuple[float, int, float], bool]:
+    ) -> Union[Tuple[float, int], Tuple[float, int, float], bool]:
         """Test for conditional independence, given some data.
 
         :param df: A dataframe.

--- a/src/y0/struct.py
+++ b/src/y0/struct.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-)
 from typing import Callable, Iterable, Literal, NamedTuple, Optional, Tuple, Union
 
 import pandas as pd

--- a/tests/test_algorithm/test_falsification.py
+++ b/tests/test_algorithm/test_falsification.py
@@ -6,19 +6,32 @@ import unittest
 
 from y0.algorithm.conditional_independencies import get_conditional_independencies
 from y0.algorithm.falsification import get_falsifications, get_graph_falsifications
-from y0.examples import asia_example
+from y0.examples import asia_example, frontdoor_backdoor_example
+from y0.struct import DSeparationJudgement, get_conditional_independence_tests
 
 
 class TestFalsification(unittest.TestCase):
     """Test the falsifiable implications."""
 
-    def test_graph_falsifications(self):
+    def test_discrete_graph_falsifications(self):
         """Test the asia graph against data generated from it."""
-        issues = get_graph_falsifications(
-            asia_example.graph, asia_example.data, method="cressie_read"
-        )
-        self.assertEqual(0, len(issues.failures))
-        self.assertGreater(len(issues.evidence), 0)
+        for method in [None, *get_conditional_independence_tests()]:
+            if method == "pearson":
+                continue
+            with self.subTest(method=method):
+                issues = get_graph_falsifications(
+                    asia_example.graph, asia_example.data, method=method
+                )
+                self.assertEqual(0, len(issues.failures))
+                self.assertGreater(len(issues.evidence), 0)
+
+    def test_continuous_graph_falsifications(self):
+        """Test the frontdoor graph against continuous data generated for it."""
+        data = frontdoor_backdoor_example.generate_data(1_000)
+        # judgements = [DSeparationJudgement(left=)]
+        get_graph_falsifications(frontdoor_backdoor_example.graph, df=data, method="pearson")
+        # TODO get a graph where we know what the outcome should be, this
+        #  should be available in https://github.com/y0-causal-inference/eliater/pull/1
 
     def test_falsifications(self):
         """Test the asia graph against data generated from it, passing in the implications to test."""

--- a/tests/test_algorithm/test_falsification.py
+++ b/tests/test_algorithm/test_falsification.py
@@ -7,7 +7,7 @@ import unittest
 from y0.algorithm.conditional_independencies import get_conditional_independencies
 from y0.algorithm.falsification import get_falsifications, get_graph_falsifications
 from y0.examples import asia_example, frontdoor_backdoor_example
-from y0.struct import DSeparationJudgement, get_conditional_independence_tests
+from y0.struct import get_conditional_independence_tests
 
 
 class TestFalsification(unittest.TestCase):


### PR DESCRIPTION
This PR fixes two distinct bugs in the code testing for conditional independence:
- First, the `method` argument was passed incorrectly to `judgement.test`, resulting in it always defaulting to `cressie_read`.
- Second, the `pearsonr` function by `pgmpy` returns a pair, unlike to all the other tests that return a triple. This wasn't handled, resulting in an error specific to using Pearson's correlation for independence testing.

To cleanly solve the second issue, I also restructured the code a bit and renamed `chi^2` to the more general `stats` in the `evidence` data frame to reflect the fact that this column contains either Chi-square statistics or the Pearson's correlation coefficient.