### PR TITLE
Automate checking binary/continous data

### DIFF
--- a/src/y0/struct.py
+++ b/src/y0/struct.py
@@ -161,7 +161,8 @@ class DSeparationJudgement:
                     f"conditional {c.name} ({type(c.name)}) not in columns {df.columns}"
                 )
 
-        # TODO extend to discrete but more than 2
+        # TODO extend to discrete but more than 2.
+        #  see https://stats.stackexchange.com/questions/12273/how-to-test-if-my-data-is-discrete-or-continuous
         # TODO what happens when some variables are binary but others are continous?
         binary = _is_binary(
             df[[self.left.name, self.right.name, *(c.name for c in self.conditions)]]

--- a/tests/test_algorithm/test_falsification.py
+++ b/tests/test_algorithm/test_falsification.py
@@ -4,6 +4,9 @@
 
 import unittest
 
+import numpy as np
+import pandas as pd
+
 from y0.algorithm.conditional_independencies import get_conditional_independencies
 from y0.algorithm.falsification import get_falsifications, get_graph_falsifications
 from y0.examples import asia_example, frontdoor_backdoor_example
@@ -24,6 +27,20 @@ class TestFalsification(unittest.TestCase):
                 )
                 self.assertEqual(0, len(issues.failures))
                 self.assertGreater(len(issues.evidence), 0)
+
+    def test_method_mismatch(self):
+        """Test when the wrong test is given."""
+        data_continuous = pd.DataFrame(
+            {v.name: np.random.normal(size=20) for v in asia_example.graph.nodes()}
+        )
+        with self.assertRaises(ValueError):
+            get_graph_falsifications(asia_example.graph, data_continuous, method="cressie_read")
+
+        data_binary = pd.DataFrame(
+            {v.name: np.random.binomial(1, 0.5, size=20) for v in asia_example.graph.nodes()}
+        )
+        with self.assertRaises(ValueError):
+            get_graph_falsifications(asia_example.graph, data_binary, method="pearson")
 
     def test_continuous_graph_falsifications(self):
         """Test the frontdoor graph against continuous data generated for it."""

--- a/tests/test_algorithm/test_falsification.py
+++ b/tests/test_algorithm/test_falsification.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from y0.algorithm.conditional_independencies import get_conditional_independencies
 from y0.algorithm.falsification import get_falsifications, get_graph_falsifications
-from y0.examples import asia_example, frontdoor_backdoor_example
+from y0.examples import asia_example, frontdoor_example
 from y0.struct import get_conditional_independence_tests
 
 
@@ -44,9 +44,8 @@ class TestFalsification(unittest.TestCase):
 
     def test_continuous_graph_falsifications(self):
         """Test the frontdoor graph against continuous data generated for it."""
-        data = frontdoor_backdoor_example.generate_data(1_000)
-        # judgements = [DSeparationJudgement(left=)]
-        get_graph_falsifications(frontdoor_backdoor_example.graph, df=data, method="pearson")
+        data = frontdoor_example.generate_data(1_000)
+        get_graph_falsifications(frontdoor_example.graph, df=data, method="pearson")
         # TODO get a graph where we know what the outcome should be, this
         #  should be available in https://github.com/y0-causal-inference/eliater/pull/1
 


### PR DESCRIPTION
As a follow-up to #193, this PR extends the default conditional independency test from just being the Cressie-Read test to dynamically checking if the data is binary or not. If it's binary, it stays with cressie read but if it's continuous, it sets it to the Pearson test.

This implementation doesn't yet consider discrete data with more than 2 values. The idea Pruthvi had in `eliater` was to manually specify a threshold. I don't like this since it's parametric, and if you already know what's going on in your data, you might as well set the test correctly. An idea for an automated test is in here for future reference: https://stats.stackexchange.com/questions/12273/how-to-test-if-my-data-is-discrete-or-continuous