### PR TITLE
Improvements for causal workflow

### DIFF
--- a/src/y0/algorithm/simplify_latent.py
+++ b/src/y0/algorithm/simplify_latent.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"""Implement Robin Evans' simplification algorithms.
+"""Implement Robin Evans' simplification algorithms from [evans2012]_ and [evans2016]_.
 
-.. seealso:: https://www.fields.utoronto.ca/programs/scientific/11-12/graphicmodels/Evans.pdf slides 34-43
+.. [evans2016] `Graphs for margins of Bayesian networks <https://arxiv.org/abs/1408.1809>`_
+.. [evans2012] `Constraints on marginalised DAGs
+      <https://www.fields.utoronto.ca/programs/scientific/11-12/graphicmodels/Evans.pdf>`_
 """
 
 import itertools as itt
@@ -35,7 +37,7 @@ def evans_simplify(
     latents: Union[None, Variable, Iterable[Variable]] = None,
     tag: Optional[str] = None,
 ) -> NxMixedGraph:
-    """Reduce the ADMG based on Evans' simplification rules.
+    """Reduce the ADMG based on Evans' simplification rules in [evans2012]_ and [evans2016]_.
 
     :param graph: an NxMixedGraph
     :param latents: Additional variables to mark as latent, in addition to the
@@ -51,8 +53,8 @@ def evans_simplify(
         for node, data in lv_dag.nodes(data=True):
             if Variable(node) in latents:
                 data[tag] = True
-    simplifiy_results = simplify_latent_dag(lv_dag, tag=tag)
-    return NxMixedGraph.from_latent_variable_dag(simplifiy_results.graph, tag=tag)
+    simplify_results = simplify_latent_dag(lv_dag, tag=tag)
+    return NxMixedGraph.from_latent_variable_dag(simplify_results.graph, tag=tag)
 
 
 class SimplifyResults(NamedTuple):
@@ -65,7 +67,7 @@ class SimplifyResults(NamedTuple):
 
 
 def simplify_latent_dag(graph: nx.DiGraph, *, tag: Optional[str] = None) -> SimplifyResults:
-    """Apply Robin Evans' four rules in succession, in place."""
+    """Apply Robin Evans' four rules in succession, in place from [evans2012]_ and [evans2016]_."""
     if tag is None:
         tag = DEFAULT_TAG
 

--- a/src/y0/algorithm/simplify_latent.py
+++ b/src/y0/algorithm/simplify_latent.py
@@ -15,7 +15,7 @@ from ..dsl import Variable
 from ..graph import DEFAULT_TAG, NxMixedGraph, _ensure_set
 
 __all__ = [
-    "evens_simplify",
+    "evans_simplify",
     "simplify_latent_dag",
     "SimplifyResults",
     "remove_widow_latents",
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_SUFFIX = "_prime"
 
 
-def evens_simplify(
+def evans_simplify(
     graph: NxMixedGraph,
     *,
     latents: Union[None, Variable, Iterable[Variable]] = None,

--- a/src/y0/graph.py
+++ b/src/y0/graph.py
@@ -931,7 +931,7 @@ def get_nodes_in_directed_paths(
         sources = {sources}
     if isinstance(outcomes, Variable):
         outcomes = {outcomes}
-    tc: nx.DiGraph = nx.transitive_closure(graph.directed, reflexive=False)
+    tc: nx.DiGraph = nx.transitive_closure_dag(graph.directed)
     intermediaries = {
         node
         for node in graph.nodes()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -15,6 +15,7 @@ from y0.graph import (
     DEFAULT_TAG,
     DEFULT_PREFIX,
     NxMixedGraph,
+    get_nodes_in_directed_paths,
     is_a_fixable,
     is_markov_blanket_shielded,
     is_p_fixable,
@@ -657,3 +658,17 @@ class TestToBayesianNetwork(unittest.TestCase):
         expected = BayesianNetwork(ebunch=[("X", "Y")])
         actual = graph.to_pgmpy_bayesian_network()
         self.assert_bayesian_equal(expected, actual)
+
+
+class TestUtilities(unittest.TestCase):
+    """Test utility functions."""
+
+    def test_nodes_in_paths(self):
+        """Test getting nodes in paths."""
+        graph = NxMixedGraph.from_edges(directed=[(X, Z), (Z, Y)])
+        self.assertEqual({X, Y, Z}, get_nodes_in_directed_paths(graph, X, Y))
+        self.assertEqual({X, Z}, get_nodes_in_directed_paths(graph, X, Z))
+        self.assertEqual({Z, Y}, get_nodes_in_directed_paths(graph, Z, Y))
+        self.assertEqual(set(), get_nodes_in_directed_paths(graph, Z, X))
+        self.assertEqual(set(), get_nodes_in_directed_paths(graph, Y, Z))
+        self.assertEqual(set(), get_nodes_in_directed_paths(graph, Y, X))


### PR DESCRIPTION
This PR makes two improvements:

1. Provides an efficient implementation to find nodes on causal paths between sources and targets
2. Provides a first-party function to apply Evans' simplification rules to an ADMG