### PR TITLE
Resolved inconsistencies in #308

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -469,12 +469,11 @@
 }
 
 @thesis{wang2023tractable,
-  abstract = {This thesis examines the application of tractable probabilistic modelling principles to causal learning and reasoning. Tractable probabilistic modelling is a promising paradigm that has emerged in recent years, which focuses on probabilistic models that enableexactandefficientprobabilistic reasoning. In particular, the framework of probabilistic circuits provides a systematic language of the tractability of models for various inference queries based on their structural properties, with recent proposals pushing the boundaries of expressiveness and tractability. However, not all information about a system can be captured through a probability distribution over observed variables; for example, the causal direction between two variables can be indistinguishable from data alone. Formalizing this, Pearl\textquoterights Causal Hierarchy (also known as theinformation hierarchy) delineates three levels of causal queries, namely, associational, interventional, and counterfactual, that require increasingly greater knowledge of the underlying causal system, represented by a structural causal model and associated causal diagram. Motivated by this, we investigate the possibility of tractable causal modelling; that is, exact and efficient reasoning with respect to classes of causal queries. In particular, we identify three scenarios, separated by the amount of knowledge available to the modeler: namely, when the full causal diagram/model is available, when only the observational distribution and identifiable causal estimand are available, and when there is additionally uncertainty over the causal diagram. In each of the scenarios, we propose probabilistic circuit representations, structural properties, and algorithms that enable efficient and exact causal reasoning. These models are distinguished from tractable probabilistic models in that they can not only answer different probabilistic inference queries, but also causal but also different interventions and even different causal diagrams. However, we also identify key limitations that cast doubt on the existence of a fully general tractable causal model. Our contributions also extend the theory of probabilistic circuits by proposing new properties and circuit architectures, which enable the analysis of advanced inference queries including, but not limited to, causal inference estimands.},
-  author   = {Wang, Benjie},
-  url      = {https://ora.ox.ac.uk/objects/uuid:2fafc463-3a9f-40cb-a48c-e33272c691b8},
-  date     = {2023},
-  title    = {Tractable Probabilistic Models for Causal Learning and Reasoning},
-  type     = {Doctoral Dissertation},
-  urldate  = {2024-01-16},
+  author  = {Wang, Benjie},
+  url     = {https://ora.ox.ac.uk/objects/uuid:2fafc463-3a9f-40cb-a48c-e33272c691b8},
+  date    = {2023},
+  title   = {Tractable Probabilistic Models for Causal Learning and Reasoning},
+  type    = {Doctoral Dissertation},
+  urldate = {2024-01-16},
 }
 

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -477,3 +477,12 @@
   urldate = {2024-01-16},
 }
 
+@misc{chirho,
+  author       = {Bingham, Eli and Witty, Sam},
+  publisher    = {GitHub},
+  date         = {2025},
+  howpublished = {\url{https://github.com/BasisResearch/chirho}},
+  journaltitle = {GitHub repository},
+  title        = {Causal Reasoning with ChiRho},
+}
+

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -456,3 +456,25 @@
   volume       = {18},
 }
 
+@inproceedings{agrawal2024automated,
+  author    = {Agrawal, Raj and Witty, Sam and Zane, Andy and Bingham, Eli},
+  editor    = {Globerson, A. and Mackey, L. and Belgrave, D. and Fan, A. and Paquet, U. and Tomczak, J. and Zhang, C.},
+  publisher = {Curran Associates, Inc.},
+  url       = {https://proceedings.neurips.cc/paper_files/paper/2024/file/1d10fe211f5139de49f94c6f0c7cecbe-Paper-Conference.pdf},
+  booktitle = {Advances in Neural Information Processing Systems},
+  date      = {2024},
+  pages     = {16102--16132},
+  title     = {Automated Efficient Estimation using Monte Carlo Efficient Influence Functions},
+  volume    = {37},
+}
+
+@thesis{wang2023tractable,
+  abstract = {This thesis examines the application of tractable probabilistic modelling principles to causal learning and reasoning. Tractable probabilistic modelling is a promising paradigm that has emerged in recent years, which focuses on probabilistic models that enableexactandefficientprobabilistic reasoning. In particular, the framework of probabilistic circuits provides a systematic language of the tractability of models for various inference queries based on their structural properties, with recent proposals pushing the boundaries of expressiveness and tractability. However, not all information about a system can be captured through a probability distribution over observed variables; for example, the causal direction between two variables can be indistinguishable from data alone. Formalizing this, Pearl\textquoterights Causal Hierarchy (also known as theinformation hierarchy) delineates three levels of causal queries, namely, associational, interventional, and counterfactual, that require increasingly greater knowledge of the underlying causal system, represented by a structural causal model and associated causal diagram. Motivated by this, we investigate the possibility of tractable causal modelling; that is, exact and efficient reasoning with respect to classes of causal queries. In particular, we identify three scenarios, separated by the amount of knowledge available to the modeler: namely, when the full causal diagram/model is available, when only the observational distribution and identifiable causal estimand are available, and when there is additionally uncertainty over the causal diagram. In each of the scenarios, we propose probabilistic circuit representations, structural properties, and algorithms that enable efficient and exact causal reasoning. These models are distinguished from tractable probabilistic models in that they can not only answer different probabilistic inference queries, but also causal but also different interventions and even different causal diagrams. However, we also identify key limitations that cast doubt on the existence of a fully general tractable causal model. Our contributions also extend the theory of probabilistic circuits by proposing new properties and circuit architectures, which enable the analysis of advanced inference queries including, but not limited to, causal inference estimands.},
+  author   = {Wang, Benjie},
+  url      = {https://ora.ox.ac.uk/objects/uuid:2fafc463-3a9f-40cb-a48c-e33272c691b8},
+  date     = {2023},
+  title    = {Tractable Probabilistic Models for Causal Learning and Reasoning},
+  type     = {Doctoral Dissertation},
+  urldate  = {2024-01-16},
+}
+

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -63,7 +63,7 @@ authors:
   - name: Haley M. Hummel
     email: haley.hummel@oregonstate.edu
     orcid: 0009-0004-5405-946X
-    affiliation: [ 2, 4 ]
+    affiliation: [2, 4]
     roles:
       - type: software
         degree: supporting
@@ -180,16 +180,16 @@ a causal query, such as:
 We present the $Y_0$ Python package, which implements causal identification
 algorithms that apply interventional, counterfactual, and transportability
 queries to data from (randomized) controlled trials, observational studies, or
-mixtures thereof. $Y_0$ focuses on the qualitative investigation of causation, helping researchers
-determine _whether_ a causal relationship can be estimated from available data
-before attempting to estimate _how strong_ that relationship is. Furthermore,
-$Y_0$ provides guidance on how to transform the causal query into a symbolic
-estimand that can be non-parametrically estimated from the available data.
-$Y_0$ provides a domain-specific language for representing causal queries and
-estimands as symbolic probabilistic expressions, tools for representing causal
-graphical models with unobserved confounders, such as acyclic directed mixed graphs
-(ADMGs), and implementations of numerous identification algorithms from the
-recent causal inference literature.
+mixtures thereof. $Y_0$ focuses on the qualitative investigation of causation,
+helping researchers determine _whether_ a causal relationship can be estimated
+from available data before attempting to estimate _how strong_ that relationship
+is. Furthermore, $Y_0$ provides guidance on how to transform the causal query
+into a symbolic estimand that can be non-parametrically estimated from the
+available data. $Y_0$ provides a domain-specific language for representing
+causal queries and estimands as symbolic probabilistic expressions, tools for
+representing causal graphical models with unobserved confounders, such as
+acyclic directed mixed graphs (ADMGs), and implementations of numerous
+identification algorithms from the recent causal inference literature.
 
 # Statement of Need
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -335,14 +335,14 @@ cases like `gID` and `gID*`. Similarly, we plan to implement probabilistic
 expression simplification [@tikka2017b] to improve the consistency of the
 estimands output from identification algorithms.
 
-[@agrawal2024automated] has recently demonstrated how to automatically generate
-an efficient and robust estimator for causal queries more sophisticated than
-`ID` using a causal extension of the Pyro probabilistic programming language
-[@bingham2018pyro] called
-[ChiRho](https://basisresearch.github.io/chirho/dr_learner.html). Probabilistic
-circuits [@darwiche2022causalinferenceusingtractable; @wang2023tractable] also
-present a new paradigm for tractable causal estimation. Such a generalization
-would enable the automation of downstream applications in experimental design.
+@agrawal2024automated recently demonstrated automatically generating an
+efficient and robust estimator for causal queries more sophisticated than `ID`
+using [ChiRho](https://basisresearch.github.io/chirho/dr_learner.html), a causal
+extension of the Pyro probabilistic programming language [@bingham2018pyro]
+called. Probabilistic circuits [@darwiche2022causalinferenceusingtractable;
+@wang2023tractable] also present a new paradigm for tractable causal estimation.
+Such a generalization would enable the automation of downstream applications in
+experimental design.
 
 # Availability and Usage
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -167,30 +167,29 @@ determined whether it is theoretically possible to estimate a causal effect from
 available data, given prior knowledge about relationships between variables and
 a causal query, such as:
 
-1. **Interventional Query**, which asks: _what will happen if we intervene?_
-   For example, what would be the average effect if everyone received treatment?
-2. **Counterfactual Query**, which asks: _what would have happened had we done something different?_ For example, would a given patient,
-   who recovered after receiving treatment, have recovered anyway without treatment?.
+1. **Interventional Query**, which asks: _what will happen if we intervene?_ For
+   example, what would be the average effect if everyone received treatment?
+2. **Counterfactual Query**, which asks: _what would have happened had we done
+   something different?_ For example, would a given patient, who recovered after
+   receiving treatment, have recovered anyway without treatment?.
 3. **Transportability Query**, which asks: _can causal findings from one
    population be validly applied to another, and if so, how can evidence from
    multiple studies or populations be combined to draw conclusions about a
    target group of interest?_
 
-We present the $Y_0$ Python package, which addresses a gap in the
-current software ecosystem by implementing causal identification
-algorithms that apply interventional, counterfactual, and
-transportability queries to data from (randomized) controlled trials,
-observational studies, or mixtures thereof.  $Y_0$ focuses on the
-qualitative investigation of causation, helping researchers determine
-_whether_ a causal relationship can be estimated from available data
-before attempting to estimate _how strong_ that relationship
-is. Furthermore, $Y_0$ provides guidance on how to transform the
-causal query into a symbolic estimand that can be non-parametrically
-estimated from the available data.  $Y_0$ provides a domain-specific
-language for representing causal queries and estimands as symbolic
-probabilistic expressions, tools for representing causal graphical models
-with unobserved confounders as acyclic directed mixed graphs (ADMG)s
-and implementations of numerous identification algorithms from the
+We present the $Y_0$ Python package, which addresses a gap in the current
+software ecosystem by implementing causal identification algorithms that apply
+interventional, counterfactual, and transportability queries to data from
+(randomized) controlled trials, observational studies, or mixtures thereof.
+$Y_0$ focuses on the qualitative investigation of causation, helping researchers
+determine _whether_ a causal relationship can be estimated from available data
+before attempting to estimate _how strong_ that relationship is. Furthermore,
+$Y_0$ provides guidance on how to transform the causal query into a symbolic
+estimand that can be non-parametrically estimated from the available data. $Y_0$
+provides a domain-specific language for representing causal queries and
+estimands as symbolic probabilistic expressions, tools for representing causal
+graphical models with unobserved confounders as acyclic directed mixed graphs
+(ADMG)s and implementations of numerous identification algorithms from the
 recent causal inference literature.
 
 # State of the Field
@@ -228,17 +227,18 @@ implementation of both previously published and future algorithms and workflows.
 
 # Implementation
 
-**Probabilistic Expressions** $Y_0$ implements an internal
-domain-specific language that can capture variables, counterfactual
-variables, population variables, and probabilistic expressions in
-which they appear. It covers the three levels of Pearl's Causal
-Hierarchy [@bareinboim2022], including association $P(Y=y \mid
-X=x^\ast)$, represented as \texttt{P(Y | \textasciitilde X)}, interventions
-$P_{do(X=x^\ast)}(Y=y, Z=z)$, represented as \texttt{P[\textasciitilde X](Y,Z)} and
-counterfactuals $P(Y_{do(X=x^\ast)}=y^\ast\mid X=x, Y=y)$, represented as
-\texttt{P(\textasciitilde Y @ \textasciitilde X | X, Y)}. Expressions can be converted to SymPy
-[@meurer2017sympy] or LaTeX expressions and be rendered in Jupyter
-notebooks.
+**Probabilistic Expressions** $Y_0$ implements an internal domain-specific
+language that can capture variables, counterfactual variables, population
+variables, and probabilistic expressions in which they appear. It covers the
+three levels of Pearl's Causal Hierarchy [@bareinboim2022], including
+association $P(Y=y \mid
+X=x^\ast)$, represented as \texttt{P(Y | \textasciitilde
+X)}, interventions $P_{do(X=x^\ast)}(Y=y, Z=z)$, represented as
+\texttt{P[\textasciitilde X](Y,Z)} and counterfactuals
+$P(Y_{do(X=x^\ast)}=y^\ast\mid X=x, Y=y)$, represented as
+\texttt{P(\textasciitilde Y @ \textasciitilde X | X, Y)}. Expressions can be
+converted to SymPy [@meurer2017sympy] or LaTeX expressions and be rendered in
+Jupyter notebooks.
 
 **Data Structure** $Y_0$ builds on NetworkX [@hagberg2008networkx] to implement
 an (acyclic) directed mixed graph data structure, used in many identification
@@ -264,7 +264,6 @@ algorithms of any causal inference package. It implements `ID`
 [@tian2010identifying], transport [@correa2020transport], and counterfactual
 transport [@correa2022cftransport].
 
-
 # Case Study
 
 We present a case study regarding the effect of how smoking relates to cancer.
@@ -277,25 +276,25 @@ following prior knowledge:
 
 ![**A**) A simplified acyclic directed graph model representing prior knowledge on smoking and cancer and **B**) a more complex acyclic directed mixed graph that explicitly represents confounding variables.](figures/cancer_tar.pdf){#cancer height="100pt"}
 
-The identification algorithm (`ID`) [@shpitser2006id] estimates the
-effect of smoking on the risk of cancer in \autoref{cancer}A as
-$\sum_{Tar} P(Cancer | Smoking, Tar) P(Tar | Smoking)$. However, the
-model in \autoref{cancer}A is inaccurate because it does not represent
-confounders between smoking and tar accumulation, such as the choice
-to smoke tar-free cigarettes. Therefore, we add a _bidirected_ edge in
-\autoref{cancer}B.  Unfortunately, `ID` can not produce an estimand
-for \autoref{cancer}B, which motivates the usage of an alternative
-algorithm that incorporates observational and/or interventional
-data. For example, if data from an observational study associating
-smoking with tar and cancer ($\pi^{\ast}$) and data from a randomized
-trial studying the causal effect of smoking on tar buildup in the
-lungs ($\pi_1$) are available, the surrogate outcomes algorithm
-(`TRSO`) [@tikka2019trso] estimates the effect of smoking on the risk
-of cancer in \autoref{cancer}B as $\sum_{Tar} P^{\pi^{\ast}}(Cancer |
-Smoking, Tar) P_{\text{Smoking}}^{{\pi_1}}(Tar)$.  Code and a more
-detailed description of this case study can be found in the following
-[Jupyter
-notebook](https://github.com/y0-causal-inference/y0/blob/main/notebooks/Surrogate%20Outcomes.ipynb).
+The identification algorithm (`ID`) [@shpitser2006id] estimates the effect of
+smoking on the risk of cancer in \autoref{cancer}A as
+$\sum_{Tar} P(Cancer | Smoking, Tar) P(Tar | Smoking)$. However, the model in
+\autoref{cancer}A is inaccurate because it does not represent confounders
+between smoking and tar accumulation, such as the choice to smoke tar-free
+cigarettes. Therefore, we add a _bidirected_ edge in \autoref{cancer}B.
+Unfortunately, `ID` can not produce an estimand for \autoref{cancer}B, which
+motivates the usage of an alternative algorithm that incorporates observational
+and/or interventional data. For example, if data from an observational study
+associating smoking with tar and cancer ($\pi^{\ast}$) and data from a
+randomized trial studying the causal effect of smoking on tar buildup in the
+lungs ($\pi_1$) are available, the surrogate outcomes algorithm (`TRSO`)
+[@tikka2019trso] estimates the effect of smoking on the risk of cancer in
+\autoref{cancer}B as
+$\sum_{Tar} P^{\pi^{\ast}}(Cancer |
+Smoking, Tar) P_{\text{Smoking}}^{{\pi_1}}(Tar)$.
+Code and a more detailed description of this case study can be found in the
+following
+[Jupyter notebook](https://github.com/y0-causal-inference/y0/blob/main/notebooks/Surrogate%20Outcomes.ipynb).
 
 We provide a second case study demonstrating the transport
 [@correa2020transport] and counterfactual transport [@correa2022cftransport]
@@ -316,37 +315,34 @@ its further development:
 
 # Future Directions
 
-There remain several high value identification algorithms to include
-in $Y_0$ in the future. For example, the cyclic identification
-algorithm (`ioID`) [@forré2019causalcalculuspresencecycles] is
-important to work with more realistic graphs that contain cycles, such
-as how biomolecular signaling pathways often contain feedback
-loops. Further, missing data identification algorithms can account for
-data that is missing not at random (MNAR) by modeling the underlying
-missingness mechanism [@mohan2021]. Implementing recent algorithms
-that provide sufficient conditions for identification in hierarchical
-causal models [@weinstein2024hierarchicalcausalmodels] would be useful
-for supporting causal identification in probabilistic programming
-languages, such as ChiRho.  Several algorithms noted in the review by
-@JSSv099i05, such as generalized identification (`gID`)
-[@lee2019general] and generalized counterfactual identification
-(`gID*`) [@correa2021counterfactual], can be formulated as special
-cases of counterfactual transportability. Therefore, we plan to
-improve the user experience by exposing more powerful algorithms like
-counterfactual transport through a simplified APIs corresponding to
-special cases like `gID` and `gID*`.  Similarly, we plan to implement
-probabilistic expression simplification [@tikka2017b] to improve the
-consistency of the estimands output from identification algorithms.
+There remain several high value identification algorithms to include in $Y_0$ in
+the future. For example, the cyclic identification algorithm (`ioID`)
+[@forré2019causalcalculuspresencecycles] is important to work with more
+realistic graphs that contain cycles, such as how biomolecular signaling
+pathways often contain feedback loops. Further, missing data identification
+algorithms can account for data that is missing not at random (MNAR) by modeling
+the underlying missingness mechanism [@mohan2021]. Implementing recent
+algorithms that provide sufficient conditions for identification in hierarchical
+causal models [@weinstein2024hierarchicalcausalmodels] would be useful for
+supporting causal identification in probabilistic programming languages, such as
+ChiRho. Several algorithms noted in the review by @JSSv099i05, such as
+generalized identification (`gID`) [@lee2019general] and generalized
+counterfactual identification (`gID*`) [@correa2021counterfactual], can be
+formulated as special cases of counterfactual transportability. Therefore, we
+plan to improve the user experience by exposing more powerful algorithms like
+counterfactual transport through a simplified APIs corresponding to special
+cases like `gID` and `gID*`. Similarly, we plan to implement probabilistic
+expression simplification [@tikka2017b] to improve the consistency of the
+estimands output from identification algorithms.
 
-[@agrawal2024automated] has recently demonstrated how to automatically
-generate an efficient and robust estimator for causal queries more
-sophisticated than `ID` using a causal extension of the Pyro
-probabilistic programming language [@bingham2018pyro] called
+[@agrawal2024automated] has recently demonstrated how to automatically generate
+an efficient and robust estimator for causal queries more sophisticated than
+`ID` using a causal extension of the Pyro probabilistic programming language
+[@bingham2018pyro] called
 [ChiRho](https://basisresearch.github.io/chirho/dr_learner.html). Probabilistic
-circuits [@darwiche2022causalinferenceusingtractable],
-[@wang2023tractable] also present a new paradigm for tractable causal
-estimation. Such a generalization would enable the automation of
-downstream applications in experimental design.
+circuits [@darwiche2022causalinferenceusingtractable], [@wang2023tractable] also
+present a new paradigm for tractable causal estimation. Such a generalization
+would enable the automation of downstream applications in experimental design.
 
 # Availability and Usage
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -342,7 +342,7 @@ an efficient and robust estimator for causal queries more sophisticated than
 `ID` using a causal extension of the Pyro probabilistic programming language
 [@bingham2018pyro] called
 [ChiRho](https://basisresearch.github.io/chirho/dr_learner.html). Probabilistic
-circuits [@darwiche2022causalinferenceusingtractable], [@wang2023tractable] also
+circuits [@darwiche2022causalinferenceusingtractable; @wang2023tractable] also
 present a new paradigm for tractable causal estimation. Such a generalization
 would enable the automation of downstream applications in experimental design.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -274,9 +274,7 @@ following prior knowledge:
 2. Accumulation of tar in the lungs increases the risk of cancer.
 3. Smoking also increases the risk of cancer directly.
 
-![**A**) A simplified acyclic directed graph model representing prior knowledge on smoking and cancer and **B
-**) a more complex acyclic directed mixed graph that explicitly represents confounding variables.](figures/cancer_tar.pdf)
-{#cancer height="100pt"}
+![**A**) A simplified acyclic directed graph model representing prior knowledge on smoking and cancer and **B**) a more complex acyclic directed mixed graph that explicitly represents confounding variables.](figures/cancer_tar.pdf){#cancer height="100pt"}
 
 The identification algorithm (`ID`) [@shpitser2006id] estimates the effect of
 smoking on the risk of cancer in \autoref{cancer}A as

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -165,29 +165,33 @@ old adage that correlation does not imply causation.
 A key step in causal inference is **causal identification** during which it is
 determined whether it is theoretically possible to estimate a causal effect from
 available data, given prior knowledge about relationships between variables and
-a causal query, such as a:
+a causal query, such as:
 
-1. **Interventional Query**, which asks: _what would happen if we intervene?_
+1. **Interventional Query**, which asks: _what will happen if we intervene?_
    For example, what would be the average effect if everyone received treatment?
-2. **Counterfactual Query**, which asks: _what would have happened to specific
-   individuals in an alternative scenario?_ For example, would a given patient,
-   who did recover, have recovered anyway without treatment?.
+2. **Counterfactual Query**, which asks: _what would have happened had we done something different?_ For example, would a given patient,
+   who recovered after receiving treatment, have recovered anyway without treatment?.
 3. **Transportability Query**, which asks: _can causal findings from one
    population be validly applied to another, and if so, how can evidence from
    multiple studies or populations be combined to draw conclusions about a
    target group of interest?_
 
-We present the $Y_0$ Python package, which addresses a gap in the current
-software ecosystem by implementing causal identification algorithms that apply
-interventional, counterfactual, and transportability queries to data from
-(randomized) controlled trials, observational studies, or mixtures thereof.
-$Y_0$ focuses on the qualitative investigation of causation, helping researchers
-determine _whether_ a causal relationship can be estimated from available data
-before attempting to estimate _how strong_ that relationship is. $Y_0$ provides
-a domain-specific language for expressing causal queries, tools for representing
-graphical causal models that represent prior knowledge about either single or
-multiple populations, and implementations of numerous identification algorithms
-from the recent causal inference literature.
+We present the $Y_0$ Python package, which addresses a gap in the
+current software ecosystem by implementing causal identification
+algorithms that apply interventional, counterfactual, and
+transportability queries to data from (randomized) controlled trials,
+observational studies, or mixtures thereof.  $Y_0$ focuses on the
+qualitative investigation of causation, helping researchers determine
+_whether_ a causal relationship can be estimated from available data
+before attempting to estimate _how strong_ that relationship
+is. Furthermore, $Y_0$ provides guidance on how to transform the
+causal query into a symbolic estimand that can be non-parametrically
+estimated from the available data.  $Y_0$ provides a domain-specific
+language for representing causal queries and estimands as symbolic
+probabilistic expressions, tools for representing causal graphical models
+with unobserved confounders as acyclic directed mixed graphs (ADMG)s
+and implementations of numerous identification algorithms from the
+recent causal inference literature.
 
 # State of the Field
 
@@ -224,14 +228,17 @@ implementation of both previously published and future algorithms and workflows.
 
 # Implementation
 
-**Probabilistic Expressions** $Y_0$ implements an internal domain-specific
-language that can capture variables, counterfactual variables, population
-variables, and probabilistic expressions in which they appear. It covers the
-three levels of Pearl's Causal Hierarchy [@bareinboim2022], including the
-probability of sufficient causation $P(Y_X \mid X^*, Y^*)$, necessary causation
-$P(Y^*_{X^*} \mid X, Y)$, and necessary and sufficient causation
-$P(Y_X, Y^*_{X^*})$. Expressions can be converted to SymPy [@meurer2017sympy] or
-LaTeX expressions and be rendered in Jupyter notebooks.
+**Probabilistic Expressions** $Y_0$ implements an internal
+domain-specific language that can capture variables, counterfactual
+variables, population variables, and probabilistic expressions in
+which they appear. It covers the three levels of Pearl's Causal
+Hierarchy [@bareinboim2022], including association $P(Y=y \mid
+X=x^\ast)$, represented as \texttt{P(Y | \textasciitilde X)}, interventions
+$P_{do(X=x^\ast)}(Y=y, Z=z)$, represented as \texttt{P[\textasciitilde X](Y,Z)} and
+counterfactuals $P(Y_{do(X=x^\ast)}=y^\ast\mid X=x, Y=y)$, represented as
+\texttt{P(\textasciitilde Y @ \textasciitilde X | X, Y)}. Expressions can be converted to SymPy
+[@meurer2017sympy] or LaTeX expressions and be rendered in Jupyter
+notebooks.
 
 **Data Structure** $Y_0$ builds on NetworkX [@hagberg2008networkx] to implement
 an (acyclic) directed mixed graph data structure, used in many identification
@@ -254,9 +261,9 @@ Verma constraints [@tian2012verma].
 algorithms of any causal inference package. It implements `ID`
 [@shpitser2006id], `IDC` [@shpitser2007idc], `ID*` [@shpitser2012idstar], `IDC*`
 [@shpitser2012idstar], surrogate outcomes (`TRSO`) [@tikka2019trso], `tian-ID`
-[@tian2010identifying], transport [@correa2020transport], counterfactual
-transport [@correa2022cftransport], and identification for causal queries over
-hierarchical causal models [@weinstein2024hierarchicalcausalmodels].
+[@tian2010identifying], transport [@correa2020transport], and counterfactual
+transport [@correa2022cftransport].
+
 
 # Case Study
 
@@ -270,22 +277,25 @@ following prior knowledge:
 
 ![**A**) A simplified acyclic directed graph model representing prior knowledge on smoking and cancer and **B**) a more complex acyclic directed mixed graph that explicitly represents confounding variables.](figures/cancer_tar.pdf){#cancer height="100pt"}
 
-The identification algorithm (`ID`) [@shpitser2006id] estimates the effect of
-smoking on the risk of cancer in \autoref{cancer}A as
-$\sum_{Tar} P(Cancer | Smoking, Tar) P(Tar | Smoking)$. However, the model in
-\autoref{cancer}A is inaccurate because it does not represent confounders
-between smoking and tar accumulation, such as the choice to smoke tar-free
-cigarettes. Therefore, we add a _bidirected_ edge in \autoref{cancer}B.
-Unfortunately, `ID` can not produce an estimand for \autoref{cancer}B, which
-motivates the usage of an alternative algorithm that incorporates observational
-and/or interventional data. For example, if data from an observational study
-($\pi^{\ast}$) and data from an interventional trial on smoking ($\pi_1$) are
-available, the surrogate outcomes algorithm (`TRSO`) [@tikka2019trso] estimates
-the effect of smoking on the risk of cancer in \autoref{cancer}B as
-$\sum_{Tar} P^{\pi^{\ast}}(Cancer | Smoking, Tar) P_{\text{Smoking}}^{{\pi_1}}(Tar)$.
-Code and a more detailed description of this case study can be found in the
-following
-[Jupyter notebook](https://github.com/y0-causal-inference/y0/blob/main/notebooks/Surrogate%20Outcomes.ipynb).
+The identification algorithm (`ID`) [@shpitser2006id] estimates the
+effect of smoking on the risk of cancer in \autoref{cancer}A as
+$\sum_{Tar} P(Cancer | Smoking, Tar) P(Tar | Smoking)$. However, the
+model in \autoref{cancer}A is inaccurate because it does not represent
+confounders between smoking and tar accumulation, such as the choice
+to smoke tar-free cigarettes. Therefore, we add a _bidirected_ edge in
+\autoref{cancer}B.  Unfortunately, `ID` can not produce an estimand
+for \autoref{cancer}B, which motivates the usage of an alternative
+algorithm that incorporates observational and/or interventional
+data. For example, if data from an observational study associating
+smoking with tar and cancer ($\pi^{\ast}$) and data from a randomized
+trial studying the causal effect of smoking on tar buildup in the
+lungs ($\pi_1$) are available, the surrogate outcomes algorithm
+(`TRSO`) [@tikka2019trso] estimates the effect of smoking on the risk
+of cancer in \autoref{cancer}B as $\sum_{Tar} P^{\pi^{\ast}}(Cancer |
+Smoking, Tar) P_{\text{Smoking}}^{{\pi_1}}(Tar)$.  Code and a more
+detailed description of this case study can be found in the following
+[Jupyter
+notebook](https://github.com/y0-causal-inference/y0/blob/main/notebooks/Surrogate%20Outcomes.ipynb).
 
 We provide a second case study demonstrating the transport
 [@correa2020transport] and counterfactual transport [@correa2022cftransport]
@@ -306,35 +316,41 @@ its further development:
 
 # Future Directions
 
-There remain several high value identification algorithms to include in $Y_0$ in
-the future. For example, the cyclic identification algorithm (`ioID`)
-[@forré2019causalcalculuspresencecycles] is important to work with more
-realistic graphs that contain cycles, such as how biomolecular signaling
-pathways often contain feedback loops. Further, missing data identification
-algorithms can account for data that is missing not at random (MNAR) by modeling
-the underlying missingness mechanism [@mohan2021]. Several algorithms noted in
-the review by @JSSv099i05, such as generalized identification (`gID`)
-[@lee2019general] and generalized counterfactual identification (`gID*`)
-[@correa2021counterfactual], can be formulated as special cases of
-counterfactual transportability. Therefore, we plan to improve the user
-experience by exposing more powerful algorithms like counterfactual transport
-through a simplified APIs corresponding to special cases like `gID` and `gID*`.
-Similarly, we plan to implement probabilistic expression simplification
-[@tikka2017b] to improve the consistency of the estimands output from
-identification algorithms.
+There remain several high value identification algorithms to include
+in $Y_0$ in the future. For example, the cyclic identification
+algorithm (`ioID`) [@forré2019causalcalculuspresencecycles] is
+important to work with more realistic graphs that contain cycles, such
+as how biomolecular signaling pathways often contain feedback
+loops. Further, missing data identification algorithms can account for
+data that is missing not at random (MNAR) by modeling the underlying
+missingness mechanism [@mohan2021]. Implementing recent algorithms
+that provide sufficient conditions for identification in hierarchical
+causal models [@weinstein2024hierarchicalcausalmodels] would be useful
+for supporting causal identification in probabilistic programming
+languages, such as ChiRho.  Several algorithms noted in the review by
+@JSSv099i05, such as generalized identification (`gID`)
+[@lee2019general] and generalized counterfactual identification
+(`gID*`) [@correa2021counterfactual], can be formulated as special
+cases of counterfactual transportability. Therefore, we plan to
+improve the user experience by exposing more powerful algorithms like
+counterfactual transport through a simplified APIs corresponding to
+special cases like `gID` and `gID*`.  Similarly, we plan to implement
+probabilistic expression simplification [@tikka2017b] to improve the
+consistency of the estimands output from identification algorithms.
 
-It remains an open research question how to estimate the causal effect for an
-arbitrary estimand produced by an algorithm more sophisticated than `ID`. Two
-potential avenues for overcoming this might be a combination of the Pyro
-probabilistic programming langauge [@bingham2018pyro] and its causal inference
-extension [ChiRho](https://github.com/BasisResearch/chirho). Tractable circuits
-[@darwiche2022causalinferenceusingtractable] also present a new paradigm for
-generic estimation. Such a generalization would be a lofty achievement and
-enable the automation of downstream applications in experimental design.
+[@agrawal2024automated] has recently demonstrated how to automatically
+generate an efficient and robust estimator for causal queries more
+sophisticated than `ID` using a causal extension of the Pyro
+probabilistic programming language [@bingham2018pyro] called
+[ChiRho](https://basisresearch.github.io/chirho/dr_learner.html). Probabilistic
+circuits [@darwiche2022causalinferenceusingtractable],
+[@wang2023tractable] also present a new paradigm for tractable causal
+estimation. Such a generalization would enable the automation of
+downstream applications in experimental design.
 
 # Availability and Usage
 
-`y0` is available as a package on [PyPI](https://pypi.org/project/y0) with the
+$Y_0$ is available as a package on [PyPI](https://pypi.org/project/y0) with the
 source code available at
 [https://github.com/y0-causal-inference/y0](https://github.com/y0-causal-inference/y0)
 under a BSD 3-clause license, archived to Zenodo at

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -234,11 +234,11 @@ three levels of Pearl's Causal Hierarchy [@bareinboim2022], including
 association $P(Y=y \mid
 X=x^\ast)$, represented as \texttt{P(Y | \textasciitilde
 X)}, interventions $P_{do(X=x^\ast)}(Y=y, Z=z)$, represented as
-\texttt{P[\textasciitilde X](Y,Z)} and counterfactuals
+\texttt{P[\textasciitilde X](Y, Z)} and counterfactuals
 $P(Y_{do(X=x^\ast)}=y^\ast\mid X=x, Y=y)$, represented as
 \texttt{P(\textasciitilde Y @ \textasciitilde X | X, Y)}. Expressions can be
-converted to SymPy [@meurer2017sympy] or LaTeX expressions and be rendered in
-Jupyter notebooks.
+converted to SymPy [@meurer2017sympy] or LaTeX expressions and can be rendered
+in Jupyter notebooks.
 
 **Data Structure** $Y_0$ builds on NetworkX [@hagberg2008networkx] to implement
 an (acyclic) directed mixed graph data structure, used in many identification
@@ -316,33 +316,35 @@ its further development:
 # Future Directions
 
 There remain several high value identification algorithms to include in $Y_0$ in
-the future. For example, the cyclic identification algorithm (`ioID`)
+the future. First, the cyclic identification algorithm (`ioID`)
 [@forré2019causalcalculuspresencecycles] is important to work with more
 realistic graphs that contain cycles, such as how biomolecular signaling
-pathways often contain feedback loops. Further, missing data identification
+pathways often contain feedback loops. Second, Missing data identification
 algorithms can account for data that is missing not at random (MNAR) by modeling
-the underlying missingness mechanism [@mohan2021]. Implementing recent
-algorithms that provide sufficient conditions for identification in hierarchical
-causal models [@weinstein2024hierarchicalcausalmodels] would be useful for
-supporting causal identification in probabilistic programming languages, such as
-ChiRho. Several algorithms noted in the review by @JSSv099i05, such as
-generalized identification (`gID`) [@lee2019general] and generalized
-counterfactual identification (`gID*`) [@correa2021counterfactual], can be
-formulated as special cases of counterfactual transportability. Therefore, we
-plan to improve the user experience by exposing more powerful algorithms like
-counterfactual transport through a simplified APIs corresponding to special
-cases like `gID` and `gID*`. Similarly, we plan to implement probabilistic
-expression simplification [@tikka2017b] to improve the consistency of the
-estimands output from identification algorithms.
+the underlying missingness mechanism [@mohan2021]. Third, algorithms that
+provide sufficient conditions for identification in hierarchical causal models
+[@weinstein2024hierarchicalcausalmodels] would be useful for supporting causal
+identification in probabilistic programming languages, such as ChiRho [@chirho].
 
+Several algorithms noted in the review by @JSSv099i05, such as generalized
+identification (`gID`) [@lee2019general] and generalized counterfactual
+identification (`gID*`) [@correa2021counterfactual], can be formulated as
+special cases of counterfactual transportability. Therefore, we plan to improve
+the user experience by exposing more powerful algorithms like counterfactual
+transport through a simplified APIs corresponding to special cases like `gID`
+and `gID*`. Similarly, we plan to implement probabilistic expression
+simplification [@tikka2017b] to improve the consistency of the estimands output
+from identification algorithms.
+
+It remains an open research question how to estimate the causal effect for an
+arbitrary estimand produced by an algorithm more sophisticated than `ID`.
 @agrawal2024automated recently demonstrated automatically generating an
 efficient and robust estimator for causal queries more sophisticated than `ID`
-using [ChiRho](https://basisresearch.github.io/chirho/dr_learner.html), a causal
-extension of the Pyro probabilistic programming language [@bingham2018pyro]
-called. Probabilistic circuits [@darwiche2022causalinferenceusingtractable;
-@wang2023tractable] also present a new paradigm for tractable causal estimation.
-Such a generalization would enable the automation of downstream applications in
-experimental design.
+using ChiRho [@chirho], a causal extension of the Pyro probabilistic programming
+language [@bingham2018pyro]. Probabilistic circuits
+[@darwiche2022causalinferenceusingtractable; @wang2023tractable] also present a
+new paradigm for tractable causal estimation. Such a generalization would enable
+the automation of downstream applications in experimental design.
 
 # Availability and Usage
 


### PR DESCRIPTION
## Summary of changes:

- [x] References to Causal Hierarchical models PR #236  have been moved to Future work section
- [x]  `y0` replaced by $Y_0$ on line 136
- [x] In the Summary, we specify that not only does the output of the identification algorithm give a qualitative answer as to whether a query is identifiable, but also that it provides guidance on how to transform the causal query into a symbolic estimand that can be non-parametrically estimated from the available data.
- [x] On line 99, ($\pi_1$) now specifies that the interventional data comes from a study that randomized on smoking, but only measured its effect on tar accumulation in the lungs (a surrogate outcome), not the effect of smoking on cancer.  By combining observational data associating smoking with tar and cancer ($\pi^\ast$) with interventional data on the surrogate outcome ($\pi_1$), we show we can identify the causal effect of smoking on cancer.
- [x] Instead of using PN, PS, and PNS, we provide a complete specification of associational, interventional and counterfactual symbolic probabilistic expressions, and their representation in the DSL.  
- [x] We demonstrate that the associational expression: $P(Y=y | X=x^\ast)$, is represented as:  `P(Y | ~X)`
- [x] Likewise, the interventional expression $P_{do(X=x~\ast)}(Y, Z)$ is represented as `P[~X](Y,Z)`.
- [x] Finally, the counterfactual expression $P(Y_{do(X=x^\ast)}=y^\ast\mid X=x, Y=y)$ is represented as `P(~Y @ ~X | X, Y)`.
- [x] Cleaned up future work so that it cited actual algorithms to implement, rather than speculating about the possibility of future algorithms to implement.
- [x] added  newly cited algorithms to bibliography.