### PR TITLE
Optimize separator search and add parallel CI tests

### DIFF
--- a/src/y0/algorithm/conditional_independencies.py
+++ b/src/y0/algorithm/conditional_independencies.py
@@ -1,9 +1,10 @@
 """An implementation to get conditional independencies of an ADMG from [pearl2009]_."""
 
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from collections.abc import Callable, Iterable, Sequence
 from functools import partial
-from itertools import combinations, groupby
-from typing import Any
+from itertools import combinations, groupby, islice
+from typing import Any, NamedTuple
 
 import networkx as nx
 import pandas as pd
@@ -114,11 +115,29 @@ def test_conditional_independencies(
 Policy = Callable[[DSeparationJudgement], Any]
 
 
+class _PairSeparationContext(NamedTuple):
+    """Pair-specific graph state reused across conditioning sets."""
+
+    evidence_graph: nx.Graph
+    condition_candidates: tuple[Variable, ...]
+
+
+class _PairBatchTask(NamedTuple):
+    """A batch of pair searches to evaluate in one worker."""
+
+    graph: NxMixedGraph
+    pairs: tuple[tuple[Variable, Variable], ...]
+    max_conditions: int | None
+    return_all: bool
+
+
 def get_conditional_independencies(
     graph: NxMixedGraph,
     *,
     policy: Policy | None = None,
     max_conditions: int | None = None,
+    n_jobs: int | None = None,
+    batch_size: int | None = None,
     **kwargs: Any,
 ) -> set[DSeparationJudgement]:
     """Get the conditional independencies from the given ADMG.
@@ -138,10 +157,26 @@ def get_conditional_independencies(
 
         Original issue https://github.com/y0-causal-inference/y0/issues/24
     """
+    if not kwargs.get("return_all", False):
+        return set(
+            d_separations(
+                graph,
+                max_conditions=max_conditions,
+                n_jobs=n_jobs,
+                batch_size=batch_size,
+                **kwargs,
+            )
+        )
     if policy is None:
         policy = get_topological_policy(graph)
     return minimal(
-        d_separations(graph, max_conditions=max_conditions, **kwargs),
+        d_separations(
+            graph,
+            max_conditions=max_conditions,
+            n_jobs=n_jobs,
+            batch_size=batch_size,
+            **kwargs,
+        ),
         policy=policy,
     )
 
@@ -207,6 +242,102 @@ def _len_lex(judgement: DSeparationJudgement) -> tuple[int, str]:
     return len(judgement.conditions), ",".join(c.name for c in judgement.conditions)
 
 
+def _prepare_pair_separation_context(
+    graph: NxMixedGraph,
+    a: Variable,
+    b: Variable,
+) -> _PairSeparationContext:
+    named = {a, b}
+    keep = graph.ancestors_inclusive(named)
+    evidence_graph = graph.subgraph(keep).moralize().disorient()
+    condition_candidates = _order_condition_candidates(
+        evidence_graph,
+        a,
+        b,
+        candidates=set(evidence_graph.nodes) - named,
+    )
+    return _PairSeparationContext(
+        evidence_graph=evidence_graph,
+        condition_candidates=condition_candidates,
+    )
+
+
+def _order_condition_candidates(
+    evidence_graph: nx.Graph,
+    a: Variable,
+    b: Variable,
+    *,
+    candidates: Iterable[Variable],
+) -> tuple[Variable, ...]:
+    """Prioritize nodes closer to the queried pair for earlier separator discovery."""
+    a_distances = nx.single_source_shortest_path_length(evidence_graph, a)
+    b_distances = nx.single_source_shortest_path_length(evidence_graph, b)
+
+    def key(node: Variable) -> tuple[float, float, float, str]:
+        a_distance = a_distances.get(node, float("inf"))
+        b_distance = b_distances.get(node, float("inf"))
+        return (a_distance + b_distance, min(a_distance, b_distance), a_distance, str(node))
+
+    return tuple(sorted(candidates, key=key))
+
+
+def _is_d_separated_in_context(
+    context: _PairSeparationContext,
+    a: Variable,
+    b: Variable,
+    *,
+    conditions: Iterable[Variable],
+) -> bool:
+    conditions = set(conditions)
+    if conditions:
+        evidence_graph = context.evidence_graph.subgraph(set(context.evidence_graph.nodes) - conditions)
+    else:
+        evidence_graph = context.evidence_graph
+    return not nx.has_path(evidence_graph, a, b)
+
+
+def _chunked(
+    iterable: Iterable[tuple[Variable, Variable]],
+    size: int,
+) -> Iterable[tuple[tuple[Variable, Variable], ...]]:
+    iterator = iter(iterable)
+    while chunk := tuple(islice(iterator, size)):
+        yield chunk
+
+
+def _get_pair_batch_size(pair_count: int, *, n_jobs: int) -> int:
+    return max(1, pair_count // (n_jobs * 4))
+
+
+def _search_pair_batch(task: _PairBatchTask) -> list[DSeparationJudgement]:
+    judgements = []
+    for a, b in task.pairs:
+        context = _prepare_pair_separation_context(task.graph, a, b)
+        for conditions in powerset(context.condition_candidates, stop=task.max_conditions):
+            if _is_d_separated_in_context(context, a, b, conditions=conditions):
+                judgements.append(
+                    DSeparationJudgement.create(left=a, right=b, conditions=conditions, separated=True)
+                )
+                if not task.return_all:
+                    break
+    return judgements
+
+
+def _parallel_search_pair_batches(
+    tasks: Sequence[_PairBatchTask],
+    *,
+    n_jobs: int,
+) -> Iterable[list[DSeparationJudgement]]:
+    try:
+        with ProcessPoolExecutor(max_workers=n_jobs) as executor:
+            yield from executor.map(_search_pair_batch, tasks)
+            return
+    except PermissionError:
+        pass
+    with ThreadPoolExecutor(max_workers=n_jobs) as executor:
+        yield from executor.map(_search_pair_batch, tasks)
+
+
 def are_d_separated(
     graph: NxMixedGraph,
     a: Variable,
@@ -256,12 +387,8 @@ def are_d_separated(
     # Filter to ancestors
     keep = graph.ancestors_inclusive(named)
     evidence_graph = graph.subgraph(keep).moralize().disorient()
-
-    keep = set(evidence_graph.nodes) - set(conditions)
-    evidence_graph = evidence_graph.subgraph(keep)
-
-    # check for path....
-    separated = not nx.has_path(evidence_graph, a, b)  # If no path, then d-separated!
+    context = _PairSeparationContext(evidence_graph=evidence_graph, condition_candidates=())
+    separated = _is_d_separated_in_context(context, a, b, conditions=conditions)
 
     return DSeparationJudgement.create(left=a, right=b, conditions=conditions, separated=separated)
 
@@ -272,6 +399,8 @@ def d_separations(
     max_conditions: int | None = None,
     verbose: bool | None = False,
     return_all: bool | None = False,
+    n_jobs: int | None = None,
+    batch_size: int | None = None,
 ) -> Iterable[DSeparationJudgement]:
     """Generate d-separations in the provided graph.
 
@@ -280,20 +409,48 @@ def d_separations(
     :param return_all: If false (default) only returns the first d-separation per
         left/right pair.
     :param verbose: If true, prints extra output with tqdm
+    :param n_jobs: Number of worker processes. Defaults to serial execution.
+    :param batch_size: Number of pairs to submit per worker task.
 
     :yields: True d-separation judgements
     """
-    vertices = set(graph.nodes())
-    for a, b in tqdm(
-        combinations(vertices, 2),
-        disable=not verbose,
-        desc="Checking d-separations",
-        unit="pair",
-        total=len(vertices) * (len(vertices) - 1) // 2,
-    ):
-        for conditions in powerset(vertices - {a, b}, stop=max_conditions):
-            judgement = are_d_separated(graph, a, b, conditions=conditions)
-            if judgement.separated:
-                yield judgement
-                if not return_all:
-                    break
+    vertices = tuple(sorted(graph.nodes(), key=str))
+    pairs = tuple(combinations(vertices, 2))
+    if n_jobs is None or n_jobs <= 1:
+        for a, b in tqdm(
+            pairs,
+            disable=not verbose,
+            desc="Checking d-separations",
+            unit="pair",
+            total=len(pairs),
+        ):
+            context = _prepare_pair_separation_context(graph, a, b)
+            for conditions in powerset(context.condition_candidates, stop=max_conditions):
+                if _is_d_separated_in_context(context, a, b, conditions=conditions):
+                    yield DSeparationJudgement.create(left=a, right=b, conditions=conditions, separated=True)
+                    if not return_all:
+                        break
+        return
+
+    if batch_size is None:
+        batch_size = _get_pair_batch_size(len(pairs), n_jobs=n_jobs)
+    tasks = [
+        _PairBatchTask(
+            graph=graph,
+            pairs=pair_batch,
+            max_conditions=max_conditions,
+            return_all=bool(return_all),
+        )
+        for pair_batch in _chunked(pairs, batch_size)
+    ]
+    iterator = tasks
+    if verbose:
+        iterator = tqdm(
+            tasks,
+            disable=not verbose,
+            desc="Checking d-separations",
+            unit="batch",
+            total=len(tasks),
+        )
+    for judgements in _parallel_search_pair_batches(tuple(iterator), n_jobs=n_jobs):
+        yield from judgements

--- a/src/y0/algorithm/falsification.py
+++ b/src/y0/algorithm/falsification.py
@@ -43,6 +43,8 @@ def get_graph_falsifications(
     *,
     significance_level: float | None = None,
     max_given: int | None = None,
+    n_jobs: int | None = None,
+    batch_size: int | None = None,
     verbose: bool = False,
     method: CITest | None = None,
     sep: str | None = None,
@@ -54,6 +56,8 @@ def get_graph_falsifications(
     :param significance_level: Significance for p-value test
     :param max_given: The maximum set size in the power set of the vertices minus the
         d-separable pairs
+    :param n_jobs: Number of worker processes to use for separator search
+    :param batch_size: Number of node pairs to submit per separator-search worker task
     :param verbose: If true, use tqdm for status updates.
     :param method: Conditional independence from :mod:`pgmpy` to use. If none, defaults
         to :func:`pgmpy.estimators.CITests.cressie_read`.
@@ -61,7 +65,13 @@ def get_graph_falsifications(
 
     :returns: Falsifications report
     """
-    judgements = get_conditional_independencies(graph, max_conditions=max_given, verbose=verbose)
+    judgements = get_conditional_independencies(
+        graph,
+        max_conditions=max_given,
+        n_jobs=n_jobs,
+        batch_size=batch_size,
+        verbose=verbose,
+    )
     return get_falsifications(
         judgements=judgements,
         df=df,

--- a/tests/test_algorithm/test_conditional_independencies.py
+++ b/tests/test_algorithm/test_conditional_independencies.py
@@ -7,10 +7,12 @@ import unittest
 from collections.abc import Iterable
 from functools import partial
 from itertools import combinations, groupby
+from unittest import mock
 
 from tests import requires_pgmpy
 from y0.algorithm.conditional_independencies import (
     are_d_separated,
+    d_separations,
     get_conditional_independencies,
 )
 from y0.dsl import AA, B, C, D, E, F, G, Variable, X, Y
@@ -428,3 +430,85 @@ class TestGetConditionalIndependencies(unittest.TestCase):
                         len(parallel_by_pair[pair].conditions),
                         len(serial_by_pair[pair].conditions),
                     )
+
+    def test_parallel_separator_search_matches_serial_with_batch_size(self):
+        """Test explicit batch sizing preserves serial separator-search semantics."""
+        graph = NxMixedGraph.from_str_edges(
+            directed=[
+                ("L0_0", "L1_0"),
+                ("L0_0", "L1_1"),
+                ("L0_1", "L1_0"),
+                ("L0_1", "L1_1"),
+                ("L1_0", "L2_0"),
+                ("L1_0", "L2_1"),
+                ("L1_1", "L2_0"),
+                ("L1_1", "L2_1"),
+            ]
+        )
+        serial = get_conditional_independencies(graph, max_conditions=2)
+        parallel = get_conditional_independencies(graph, max_conditions=2, n_jobs=2, batch_size=1)
+        self.assertEqual(
+            {(judgement.left.name, judgement.right.name) for judgement in serial},
+            {(judgement.left.name, judgement.right.name) for judgement in parallel},
+        )
+
+    def test_parallel_return_all_matches_serial(self):
+        """Test return_all path works with parallel options."""
+        graph = NxMixedGraph.from_str_edges(
+            directed=[
+                ("X", "Z"),
+                ("Z", "Y"),
+                ("W", "Z"),
+            ]
+        )
+        serial = get_conditional_independencies(graph, max_conditions=2, return_all=True)
+        parallel = get_conditional_independencies(
+            graph,
+            max_conditions=2,
+            return_all=True,
+            n_jobs=2,
+            batch_size=1,
+        )
+        self.assertEqual(serial, parallel)
+
+    def test_parallel_separator_search_falls_back_to_threads(self):
+        """Test thread fallback is used when process pools are unavailable."""
+        graph = NxMixedGraph.from_str_edges(
+            directed=[
+                ("X", "Z"),
+                ("Z", "Y"),
+                ("W", "Z"),
+            ]
+        )
+
+        class FailingProcessPoolExecutor:
+            def __init__(self, *args, **kwargs):
+                raise PermissionError("simulated sandbox restriction")
+
+        with mock.patch(
+            "y0.algorithm.conditional_independencies.ProcessPoolExecutor",
+            FailingProcessPoolExecutor,
+        ):
+            serial = get_conditional_independencies(graph, max_conditions=2)
+            parallel = get_conditional_independencies(
+                graph,
+                max_conditions=2,
+                n_jobs=2,
+                batch_size=1,
+            )
+        self.assertEqual(
+            {(judgement.left.name, judgement.right.name) for judgement in serial},
+            {(judgement.left.name, judgement.right.name) for judgement in parallel},
+        )
+
+    def test_parallel_d_separations_verbose(self):
+        """Test verbose parallel d-separations path returns judgements."""
+        graph = NxMixedGraph.from_str_edges(
+            directed=[
+                ("X", "Z"),
+                ("Z", "Y"),
+                ("W", "Z"),
+            ]
+        )
+        judgements = list(d_separations(graph, max_conditions=2, n_jobs=2, batch_size=1, verbose=True))
+        self.assertTrue(judgements)

--- a/tests/test_algorithm/test_conditional_independencies.py
+++ b/tests/test_algorithm/test_conditional_independencies.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import typing
 import unittest
 from collections.abc import Iterable
+from functools import partial
+from itertools import combinations, groupby
 
 from tests import requires_pgmpy
 from y0.algorithm.conditional_independencies import (
@@ -21,6 +23,7 @@ from y0.examples import (
 )
 from y0.graph import NxMixedGraph, iter_moral_links
 from y0.struct import CITestTuple, DSeparationJudgement
+from y0.util.combinatorics import powerset
 
 
 class TestDSeparation(unittest.TestCase):
@@ -274,3 +277,154 @@ class TestGetConditionalIndependencies(unittest.TestCase):
         # Test that an error is thrown if using a continous test on discrete data
         with self.assertRaises(ValueError):
             judgement.test(data, method="pearson", boolean=True)
+
+    def test_optimized_separator_search_matches_legacy(self):
+        """Test optimized separator search preserves legacy pair coverage and condition complexity."""
+
+        def legacy_judgement_grouper(
+            judgement: DSeparationJudgement,
+        ) -> tuple[Variable, Variable]:
+            return judgement.left, judgement.right
+
+        def legacy_topological_policy(
+            judgement: DSeparationJudgement, order: list[Variable]
+        ) -> tuple[int, int]:
+            return (
+                len(judgement.conditions),
+                sum(order.index(v) for v in judgement.conditions),
+            )
+
+        def legacy_get_topological_policy(graph: NxMixedGraph):
+            order = list(graph.topological_sort())
+            return partial(legacy_topological_policy, order=order)
+
+        def legacy_minimal(
+            judgements: Iterable[DSeparationJudgement],
+            graph: NxMixedGraph,
+        ) -> set[DSeparationJudgement]:
+            policy = legacy_get_topological_policy(graph)
+            judgements = sorted(judgements, key=legacy_judgement_grouper)
+            return {
+                min(vs, key=policy)
+                for _, vs in groupby(judgements, legacy_judgement_grouper)
+            }
+
+        def legacy_d_separations(
+            graph: NxMixedGraph,
+            *,
+            max_conditions: int | None = None,
+        ) -> Iterable[DSeparationJudgement]:
+            vertices = set(graph.nodes())
+            for a, b in combinations(vertices, 2):
+                for conditions in powerset(vertices - {a, b}, stop=max_conditions):
+                    judgement = are_d_separated(graph, a, b, conditions=conditions)
+                    if judgement.separated:
+                        yield judgement
+                        break
+
+        def legacy_get_conditional_independencies(
+            graph: NxMixedGraph,
+            *,
+            max_conditions: int | None = None,
+        ) -> set[DSeparationJudgement]:
+            return legacy_minimal(
+                legacy_d_separations(graph, max_conditions=max_conditions),
+                graph,
+            )
+
+        def build_separator_search_graph(width: int = 4, depth: int = 3) -> NxMixedGraph:
+            directed = []
+            layers = []
+            for layer_index in range(depth):
+                layer = [f"L{layer_index}_{node_index}" for node_index in range(width)]
+                layers.append(layer)
+            for source_layer, target_layer in zip(layers, layers[1:], strict=False):
+                for source in source_layer:
+                    for target in target_layer:
+                        directed.append((source, target))
+            return NxMixedGraph.from_str_edges(directed=directed)
+
+        def build_ci_throughput_graph(
+            components: int = 4, chain_length: int = 4
+        ) -> NxMixedGraph:
+            directed = []
+            for component_index in range(components):
+                prefix = f"C{component_index}"
+                for node_index in range(chain_length - 1):
+                    directed.append(
+                        (f"{prefix}_{node_index}", f"{prefix}_{node_index + 1}")
+                    )
+            return NxMixedGraph.from_str_edges(directed=directed)
+
+        for graph in [
+            build_separator_search_graph(),
+            build_ci_throughput_graph(),
+        ]:
+            with self.subTest(graph=graph):
+                observed = get_conditional_independencies(graph, max_conditions=2)
+                expected = legacy_get_conditional_independencies(graph, max_conditions=2)
+
+                observed_pairs = {(judgement.left.name, judgement.right.name) for judgement in observed}
+                expected_pairs = {(judgement.left.name, judgement.right.name) for judgement in expected}
+                self.assertEqual(expected_pairs, observed_pairs)
+
+                observed_by_pair = {
+                    (judgement.left.name, judgement.right.name): judgement for judgement in observed
+                }
+                for judgement in expected:
+                    pair = (judgement.left.name, judgement.right.name)
+                    self.assertLessEqual(
+                        len(observed_by_pair[pair].conditions),
+                        len(judgement.conditions),
+                    )
+
+    def test_parallel_separator_search_matches_serial(self):
+        """Test parallel separator search matches serial output semantics."""
+
+        def build_separator_search_graph(width: int = 4, depth: int = 3) -> NxMixedGraph:
+            directed = []
+            layers = []
+            for layer_index in range(depth):
+                layer = [f"L{layer_index}_{node_index}" for node_index in range(width)]
+                layers.append(layer)
+            for source_layer, target_layer in zip(layers, layers[1:], strict=False):
+                for source in source_layer:
+                    for target in target_layer:
+                        directed.append((source, target))
+            return NxMixedGraph.from_str_edges(directed=directed)
+
+        def build_ci_throughput_graph(
+            components: int = 4, chain_length: int = 4
+        ) -> NxMixedGraph:
+            directed = []
+            for component_index in range(components):
+                prefix = f"C{component_index}"
+                for node_index in range(chain_length - 1):
+                    directed.append(
+                        (f"{prefix}_{node_index}", f"{prefix}_{node_index + 1}")
+                    )
+            return NxMixedGraph.from_str_edges(directed=directed)
+
+        for graph in [
+            build_separator_search_graph(),
+            build_ci_throughput_graph(),
+        ]:
+            with self.subTest(graph=graph):
+                serial = get_conditional_independencies(graph, max_conditions=2)
+                parallel = get_conditional_independencies(graph, max_conditions=2, n_jobs=2)
+
+                serial_pairs = {(judgement.left.name, judgement.right.name) for judgement in serial}
+                parallel_pairs = {(judgement.left.name, judgement.right.name) for judgement in parallel}
+                self.assertEqual(serial_pairs, parallel_pairs)
+
+                serial_by_pair = {
+                    (judgement.left.name, judgement.right.name): judgement for judgement in serial
+                }
+                parallel_by_pair = {
+                    (judgement.left.name, judgement.right.name): judgement for judgement in parallel
+                }
+                for pair in serial_pairs:
+                    self.assertLessEqual(
+                        len(parallel_by_pair[pair].conditions),
+                        len(serial_by_pair[pair].conditions),
+                    )


### PR DESCRIPTION

## Problem

In large (1000+ node) graphs, the falsification algorithm becomes a major bottleneck in processing time. For example see below for an example graph with >300k d-separations which would take over 300 hours.

Checking d-separations:   0%|          | 1/318801 [00:03<315:02:18,  3.56s/pair]

## Summary

This PR speeds up graph falsification by reducing the cost of separator search in get_conditional_independencies() and adding optional parallelism for the separator-search phase.

The main changes are:

- Cache pair-specific separator-search state so each (a, b) pair reuses its ancestral moralized evidence graph across candidate conditioning sets.
- Restrict candidate conditioning variables to the pair-specific ancestral graph instead of all graph vertices.
- Prioritize candidate conditioning variables by proximity to the queried pair to improve early exit.
- Skip unnecessary minimal() / policy work in the default return_all=False path.
- Add optional n_jobs and batch_size parameters for separator-search parallelization across node-pair batches.
- Thread these options through get_graph_falsifications().

This PR also adds test coverage to ensure the optimization preserves correctness:

- Compare the optimized separator search against the legacy search on representative synthetic graphs.
- Check that parallel separator search matches serial behavior semantically.

Benchmarks used during development showed the main bottleneck was separator search, not the downstream CI tests, and these changes were aimed specifically at that part of the pipeline.